### PR TITLE
add mass for python

### DIFF
--- a/dart/neural/BackpropSnapshot.cpp
+++ b/dart/neural/BackpropSnapshot.cpp
@@ -414,7 +414,7 @@ LossGradientHighLevelAPI BackpropSnapshot::backpropState(
     }
     grad.lossWrtAction(i) = thisTimestepLoss.lossWrtTorque(actionMapping[i]);
   }
-  grad.lossWrtMass = Eigen::VectorXs::Zero(0);
+  grad.lossWrtMass = thisTimestepLoss.lossWrtMass;
   return grad;
 }
 

--- a/python/_nimblephysics/neural/WithRespectToMass.cpp
+++ b/python/_nimblephysics/neural/WithRespectToMass.cpp
@@ -67,6 +67,12 @@ void WithRespectToMass(py::module& m)
       .value(
           "INERTIA_FULL", dart::neural::WrtMassBodyNodeEntryType::INERTIA_FULL)
       .export_values();
+  ::py::class_<dart::neural::WrtMassBodyNodyEntry>(
+      m, "WrtMassBodyNodyEntry")
+      .def(::py::init<
+            const std::string &, dart::neural::WrtMassBodyNodeEntryType>())
+      .def_readwrite("linkName", &dart::neural::WrtMassBodyNodyEntry::linkName)
+      .def_readwrite("type", &dart::neural::WrtMassBodyNodyEntry::type);
 }
 
 } // namespace python


### PR DESCRIPTION
- [x] Replace zero `grad.lossWrtMass` with `lossWrtMass` in `BackpropSnapshot.cpp`.
- [x] Add python binding for `WrtMassBodyNodyEntry`.
- [x] Add mass as a default arg to `TimestepLayer`.
- [x] Add forward and backward pass for mass inside `TimestepLayer`.