### PR TITLE
Tentative multi-threading in runMultiTrialKinematicsPipeline()

### DIFF
--- a/dart/biomechanics/MarkerFitter.hpp
+++ b/dart/biomechanics/MarkerFitter.hpp
@@ -336,6 +336,9 @@ public:
       dynamics::MarkerMap markers,
       bool ignoreVirtualJointCenterMarkers = false);
 
+  /// This is a copy constructor
+  MarkerFitter(const MarkerFitter& toCopy);
+
   /// This just checks if there are enough markers in the data with the names
   /// expected by the model. Returns true if there are enough, and false
   /// otherwise.


### PR DESCRIPTION
This is an attempt to alleviate the single-threaded bottlenecks in `MarkerFitter::runMultiTrialKinematicsPipeline()` when bulk processing lots of trials on a big multi-core workstation.

It has not yet been tested with more than 1 trial (which doesn't really test it at all). We should give it a try with a much larger number of trials before merging it in.