### PR TITLE
Stop dropping frames on Sam's data

### DIFF
--- a/dart/biomechanics/DynamicsFitter.cpp
+++ b/dart/biomechanics/DynamicsFitter.cpp
@@ -9793,12 +9793,12 @@ void DynamicsFitter::estimateFootGroundContacts(
 
         offForcePlate.push_back(contactIsSus);
       }
-      // if (anyContactIsSus)
-      // {
-      //   std::cout << "Marking trial " << trial << ", timestep " << t
-      //             << " as probably missing GRF, due to contact heuristic"
-      //             << std::endl;
-      // }
+      if (anyContactIsSus)
+      {
+        std::cout << "Marking trial " << trial << ", timestep " << t
+                  << " as probably missing GRF, due to contact heuristic"
+                  << std::endl;
+      }
 
       trialForceActive.push_back(forceActive);
       trialSphereInContact.push_back(sphereInContact);

--- a/dart/biomechanics/DynamicsFitter.cpp
+++ b/dart/biomechanics/DynamicsFitter.cpp
@@ -9652,8 +9652,8 @@ void DynamicsFitter::estimateFootGroundContacts(
         }
       }
 
-      // Add 10cm to each side, to be very conservative
-      s_t padding = 0.10;
+      // Add 20cm to each side, to be very conservative
+      s_t padding = 0.20;
       minX -= padding;
       maxX += padding;
       minZ -= padding;
@@ -9793,6 +9793,12 @@ void DynamicsFitter::estimateFootGroundContacts(
 
         offForcePlate.push_back(contactIsSus);
       }
+      // if (anyContactIsSus)
+      // {
+      //   std::cout << "Marking trial " << trial << ", timestep " << t
+      //             << " as probably missing GRF, due to contact heuristic"
+      //             << std::endl;
+      // }
 
       trialForceActive.push_back(forceActive);
       trialSphereInContact.push_back(sphereInContact);
@@ -9888,6 +9894,8 @@ void DynamicsFitter::fillInMissingGRFBlips(
         }
         if (isBlip)
         {
+          std::cout << "Filling in GRF blip on trial " << trial << ", timestep "
+                    << t << std::endl;
           for (int scanForward = 0; scanForward < blipFilterLen; scanForward++)
           {
             int scanT = t + scanForward;

--- a/dart/biomechanics/MarkerFixer.cpp
+++ b/dart/biomechanics/MarkerFixer.cpp
@@ -310,7 +310,7 @@ void LabeledMarkerTrace::filterTimestepsBasedOnAcc(s_t dt, s_t accThreshold)
 /// If a marker is below a certain velocity for a certain number of timesteps
 /// (or more) then mark all the timesteps where the marker is still as
 /// filtered out.
-void LabeledMarkerTrace::filterTimestepsBasedOnProlongedStillnes(
+void LabeledMarkerTrace::filterTimestepsBasedOnProlongedStillness(
     s_t dt, s_t velThreshold, int numTimesteps)
 {
   for (int i = 0; i < mPoints.size(); i++)
@@ -829,7 +829,7 @@ std::shared_ptr<MarkersErrorReport> MarkerFixer::generateDataErrorsReport(
     }
     std::string bestLabel = traces[i].getBestLabel(alreadyTakenLabels);
     traces[i].filterTimestepsBasedOnAcc(dt, 1000.0);
-    traces[i].filterTimestepsBasedOnProlongedStillnes(dt, 0.001, 10);
+    traces[i].filterTimestepsBasedOnProlongedStillness(dt, 0.001, 10);
     traceLabels.push_back(bestLabel);
   }
 

--- a/dart/biomechanics/MarkerFixer.cpp
+++ b/dart/biomechanics/MarkerFixer.cpp
@@ -302,8 +302,89 @@ void LabeledMarkerTrace::filterTimestepsBasedOnAcc(s_t dt, s_t accThreshold)
       mAccNorm.push_back(0);
     }
 
-    mDropPoint.push_back(shouldDrop);
+    mDropPointForAcc.push_back(shouldDrop);
   }
+}
+
+//==============================================================================
+/// If a marker is below a certain velocity for a certain number of timesteps
+/// (or more) then mark all the timesteps where the marker is still as
+/// filtered out.
+void LabeledMarkerTrace::filterTimestepsBasedOnProlongedStillnes(
+    s_t dt, s_t velThreshold, int numTimesteps)
+{
+  for (int i = 0; i < mPoints.size(); i++)
+    mDropPointForStillness.push_back(false);
+
+  int startDrop = -1;
+  for (int i = 0; i < mPoints.size(); i++)
+  {
+    if (i > 0)
+    {
+      Eigen::Vector3s vel = (mPoints[i] - mPoints[i - 1]) / dt;
+      s_t velNorm = vel.norm();
+      mVelNorm.push_back(velNorm);
+      if (velNorm < velThreshold)
+      {
+        if (startDrop == -1)
+        {
+          startDrop = i;
+        }
+      }
+      else if (startDrop != -1)
+      {
+        int duration = i - startDrop;
+        if (duration >= numTimesteps)
+        {
+          for (int j = startDrop; j < i; j++)
+          {
+            mDropPointForStillness[j] = true;
+          }
+        }
+        startDrop = -1;
+      }
+    }
+    else
+    {
+      mVelNorm.push_back(0);
+    }
+  }
+  if (startDrop != -1)
+  {
+    int duration = mPoints.size() - startDrop;
+    if (duration >= numTimesteps)
+    {
+      for (int j = startDrop; j < mPoints.size(); j++)
+      {
+        mDropPointForStillness[j] = true;
+      }
+    }
+    startDrop = -1;
+  }
+}
+
+//==============================================================================
+/// This is a useful measurement to test if the marker just never moves from
+/// its starting point (generally if your optical setup accidentally captured
+/// a shiny object that is fixed in place as a marker).
+s_t LabeledMarkerTrace::getMaxMarkerMovementFromStart()
+{
+  if (mPoints.size() < 2)
+  {
+    return 0.0;
+  }
+
+  s_t maxDist = 0.0;
+  Eigen::Vector3s startPoint = mPoints[0];
+  for (int i = 1; i < mPoints.size(); i++)
+  {
+    s_t dist = (mPoints[i] - startPoint).norm();
+    if (dist > maxDist)
+    {
+      maxDist = dist;
+    }
+  }
+  return maxDist;
 }
 
 //==============================================================================
@@ -748,6 +829,7 @@ std::shared_ptr<MarkersErrorReport> MarkerFixer::generateDataErrorsReport(
     }
     std::string bestLabel = traces[i].getBestLabel(alreadyTakenLabels);
     traces[i].filterTimestepsBasedOnAcc(dt, 1000.0);
+    traces[i].filterTimestepsBasedOnProlongedStillnes(dt, 0.001, 10);
     traceLabels.push_back(bestLabel);
   }
 
@@ -763,7 +845,8 @@ std::shared_ptr<MarkersErrorReport> MarkerFixer::generateDataErrorsReport(
       if (index != -1)
       {
         // Ignore points that we specifically asked to drop
-        if (index < traces[j].mDropPoint.size() && traces[j].mDropPoint[index])
+        if (index < traces[j].mDropPointForAcc.size()
+            && traces[j].mDropPointForAcc[index])
         {
           report->warnings.push_back(
               "Marker " + traceLabels[j]
@@ -771,14 +854,20 @@ std::shared_ptr<MarkersErrorReport> MarkerFixer::generateDataErrorsReport(
               + std::to_string((double)traces[j].mAccNorm[index])
               + " m/s^2) on frame " + std::to_string(t));
         }
+        else if (
+            index < traces[j].mDropPointForStillness.size()
+            && traces[j].mDropPointForStillness[index])
+        {
+          report->warnings.push_back(
+              "Marker " + traceLabels[j] + " dropped for velocity too slow ("
+              + std::to_string((double)traces[j].mVelNorm[index])
+              + " m/s) on sequential frame " + std::to_string(t));
+        }
         else
         {
           Eigen::Vector3s point = traces[j].mPoints[index];
           frame[traceLabels[j]] = point;
         }
-
-        Eigen::Vector3s point = traces[j].mPoints[index];
-        frame[traceLabels[j]] = point;
       }
     }
     correctedObservations.push_back(frame);

--- a/dart/biomechanics/MarkerFixer.hpp
+++ b/dart/biomechanics/MarkerFixer.hpp
@@ -93,7 +93,7 @@ public:
   /// If a marker is below a certain velocity for a certain number of timesteps
   /// (or more) then mark all the timesteps where the marker is still as
   /// filtered out.
-  void filterTimestepsBasedOnProlongedStillnes(
+  void filterTimestepsBasedOnProlongedStillness(
       s_t dt, s_t velThreshold, int numTimesteps);
 
   /// This is a useful measurement to test if the marker just never moves from

--- a/dart/biomechanics/MarkerFixer.hpp
+++ b/dart/biomechanics/MarkerFixer.hpp
@@ -90,13 +90,26 @@ public:
   /// acceleration.
   void filterTimestepsBasedOnAcc(s_t dt, s_t accThreshold);
 
+  /// If a marker is below a certain velocity for a certain number of timesteps
+  /// (or more) then mark all the timesteps where the marker is still as
+  /// filtered out.
+  void filterTimestepsBasedOnProlongedStillnes(
+      s_t dt, s_t velThreshold, int numTimesteps);
+
+  /// This is a useful measurement to test if the marker just never moves from
+  /// its starting point (generally if your optical setup accidentally captured
+  /// a shiny object that is fixed in place as a marker).
+  s_t getMaxMarkerMovementFromStart();
+
 public:
   int mMinTime;
   int mMaxTime;
   std::vector<int> mTimes;
   std::vector<Eigen::Vector3s> mPoints;
   std::vector<s_t> mAccNorm;
-  std::vector<bool> mDropPoint;
+  std::vector<bool> mDropPointForAcc;
+  std::vector<s_t> mVelNorm;
+  std::vector<bool> mDropPointForStillness;
   std::vector<std::string> mMarkerLabels;
 };
 

--- a/dart/biomechanics/OpenSimParser.cpp
+++ b/dart/biomechanics/OpenSimParser.cpp
@@ -107,9 +107,9 @@ std::string to_string(double d)
 // https://www.geeksforgeeks.org/round-the-given-number-to-nearest-multiple-of-10/
 int roundToNearestMultiple(int n, int multiple)
 {
-    int a = (n / multiple) * multiple;
-    int b = a + multiple;
-    return (n - a > b - n) ? b : a;
+  int a = (n / multiple) * multiple;
+  int b = a + multiple;
+  return (n - a > b - n) ? b : a;
 }
 
 //==============================================================================
@@ -1263,9 +1263,9 @@ void OpenSimParser::updateCustomJointXML(
               joint->getCustomFunction(index).get());
 
       std::string coeffString = "";
-      for (int i = polynomial->mCoeffs.size()-1; i >= 0; --i)
+      for (int i = polynomial->mCoeffs.size() - 1; i >= 0; --i)
       {
-        if (i < polynomial->mCoeffs.size()-1)
+        if (i < polynomial->mCoeffs.size() - 1)
           coeffString += " ";
         coeffString += to_string((double)polynomial->mCoeffs[i]);
       }
@@ -2054,7 +2054,8 @@ OpenSimTRC OpenSimParser::loadTRC(
           markerSwapSpace(axisNumber) = atof(token.c_str()) * unitsMultiplier;
           if (axisNumber == 2)
           {
-            if (!markerSwapSpace.hasNaN())
+            if (!markerSwapSpace.hasNaN()
+                && (markerSwapSpace != Eigen::Vector3s::Zero()))
             {
               markerPositions[markerNames[markerNumber]]
                   = Eigen::Vector3s(markerSwapSpace);
@@ -2100,7 +2101,8 @@ OpenSimTRC OpenSimParser::loadTRC(
     int frames = result.timestamps.size();
     s_t elapsed = result.timestamps[result.timestamps.size() - 1]
                   - result.timestamps[0];
-    result.framesPerSecond = roundToNearestMultiple((int)(frames / elapsed), 10);
+    result.framesPerSecond
+        = roundToNearestMultiple((int)(frames / elapsed), 10);
   }
 
   return result;

--- a/unittests/unit/test_DynamicsFitter.cpp
+++ b/unittests/unit/test_DynamicsFitter.cpp
@@ -3102,6 +3102,20 @@ std::shared_ptr<DynamicsInitialization> runEngine(
             << fitter.computeAverageForceMagnitudeChange(init) << " N"
             << std::endl;
 
+  for (int trial = 0; trial < init->probablyMissingGRF.size(); trial++)
+  {
+    int totalFrames = 0;
+    for (int t = 0; t < init->probablyMissingGRF[trial].size(); t++)
+    {
+      if (init->probablyMissingGRF[trial][t])
+      {
+        totalFrames++;
+      }
+    }
+    std::cout << "Trial " << trial << " missing GRF: " << totalFrames
+              << std::endl;
+  }
+
   if (saveGUI)
   {
     int trajectoryIndex = 0;
@@ -6273,7 +6287,7 @@ TEST(DynamicsFitter, MARKERS_TO_DYNAMICS_SPRINTER_WITH_SPINE)
 #endif
 
 #ifdef ALL_TESTS
-TEST(DynamicsFitter, MARKERS_TO_DYNAMICS_SPRINTER_WITH_SPINE)
+TEST(DynamicsFitter, MARKERS_TO_DYNAMICS_SAM_DATA)
 {
   std::vector<std::string> motFiles;
   std::vector<std::string> c3dFiles;


### PR DESCRIPTION
This PR does a few things in order to get Sam's data (at least subject 17) to process without dropping any frames.

**IMPORTANT:** In order for this to work, you have to edit the RTH2 marker on subject 17, trial "run500", to be all (0,0,0). The first 200 or so frames are already (0,0,0), and then it vibrates out of control. Here's the updated "run500" folder:
[run500.zip](https://github.com/keenon/nimblephysics/files/10946594/run500.zip)

- When loading markers from TRC files, we now drop markers that are (0,0,0), since that pretty much always indicates the marker was not observed
- When a marker is still for a suspiciously long period of time (velocity less than 0.5cm / sec for more than 10 frames, currenty), we assume that the marker has fallen off the body and we mark that marker as invisible. **Question:** should this threshold be more aggressive to avoid dropping markers in static trials?
- When loading GRF data from MOT files, we don't get information about force plate boundaries, so we infer it from where the CoPs are over time, and drawing a box around those. The padding on that box has expanded from 10cm to 20cm, on the assumption that most people step pretty far from the very edge of their force plates. This way, we throw out fewer frames, because our heuristic for throwing out frames gets much more aggressive if you're stepping off a force plate, and with more padding you're less likely to be off a force plate.