### PR TITLE
Create enum to record reasons for marking GRF frame as "missing" // writeCSVData fix

### DIFF
--- a/dart/biomechanics/DynamicsFitter.cpp
+++ b/dart/biomechanics/DynamicsFitter.cpp
@@ -9140,6 +9140,7 @@ std::shared_ptr<DynamicsInitialization> DynamicsFitter::retargetInitialization(
   std::shared_ptr<DynamicsInitialization> retargeted
       = std::make_shared<DynamicsInitialization>();
   retargeted->probablyMissingGRF = init->probablyMissingGRF;
+  retargeted->missingGRFReason = init->missingGRFReason;
 
   for (int i = 0; i < init->joints.size(); i++)
   {
@@ -9702,6 +9703,7 @@ void DynamicsFitter::estimateFootGroundContacts(
     std::vector<std::vector<bool>> trialSphereInContact;
     std::vector<std::vector<bool>> trialOffForcePlate;
     std::vector<bool> trialAnyOffForcePlate;
+    std::vector<MissingGRFReason> trialMissingGRFReason;
     for (int t = 0; t < init->poseTrials[trial].cols(); t++)
     {
       mSkeleton->setPositions(init->poseTrials[trial].col(t));
@@ -9710,6 +9712,7 @@ void DynamicsFitter::estimateFootGroundContacts(
       std::vector<bool> sphereInContact;
       std::vector<bool> offForcePlate;
       bool anyContactIsSus = false;
+      MissingGRFReason reason = MissingGRFReason::notMissingGRF;
       for (int b = 0; b < init->grfBodyNodes.size(); b++)
       {
         // 4.1. Check the GRF to see if we are measured as being in contact
@@ -9794,6 +9797,7 @@ void DynamicsFitter::estimateFootGroundContacts(
           {
             contactIsSus = true;
             anyContactIsSus = true;
+            reason = MissingGRFReason::notOverForcePlate;
             std::cout << "DEBUG estimateFootGroundContacts: GRF and contact detected, but no force plate detected. Ignoring frame " << t << "..." << std::endl;
           }
         }
@@ -9805,12 +9809,14 @@ void DynamicsFitter::estimateFootGroundContacts(
       trialSphereInContact.push_back(sphereInContact);
       trialOffForcePlate.push_back(offForcePlate);
       trialAnyOffForcePlate.push_back(anyContactIsSus);
+      trialMissingGRFReason.push_back(reason);
     }
 
     init->grfBodyForceActive.push_back(trialForceActive);
     init->grfBodySphereInContact.push_back(trialSphereInContact);
     init->grfBodyOffForcePlate.push_back(trialOffForcePlate);
     init->probablyMissingGRF.push_back(trialAnyOffForcePlate);
+    init->missingGRFReason.push_back(trialMissingGRFReason);
   }
 
   fillInMissingGRFBlips(init);
@@ -9856,6 +9862,7 @@ void DynamicsFitter::markMissingImpacts(
           {
             std::cout << "DEBUG markMissingImpacts: impact or liftoff detected, but ??? on frame" << t << "..." << std::endl;
             init->probablyMissingGRF[trial][offsetT] = true;
+            init->missingGRFReason[trial][offsetT] = MissingGRFReason::missingImpact;
           }
         }
       }
@@ -9902,6 +9909,7 @@ void DynamicsFitter::fillInMissingGRFBlips(
             if (scanT < init->probablyMissingGRF[trial].size())
             {
               init->probablyMissingGRF[trial][scanT] = true;
+              init->missingGRFReason[trial][scanT] = MissingGRFReason::missingBlip;
               std::cout << "DEBUG fillMissingGRFBlips: ??? on frame " << t << "..." << std::endl;
             }
           }
@@ -10144,6 +10152,7 @@ void DynamicsFitter::estimateUnmeasuredExternalForces(
                   << trial << " at time " << t << std::endl;
         filteredTimesteps.push_back(t + 1);
         init->probablyMissingGRF[trial][t + 1] = true;
+        init->missingGRFReason[trial][t + 1] = MissingGRFReason::unmeasuredForce;
         continue;
       }
       else if (!isEstimatedZero && isMeasuredZero)
@@ -10154,6 +10163,7 @@ void DynamicsFitter::estimateUnmeasuredExternalForces(
                     << std::endl;
           filteredTimesteps.push_back(t + 1);
           init->probablyMissingGRF[trial][t + 1] = true;
+          init->missingGRFReason[trial][t + 1] = MissingGRFReason::missingGRF;
         }
         continue;
       }
@@ -10192,6 +10202,7 @@ void DynamicsFitter::estimateUnmeasuredExternalForces(
             << threshold << ")" << std::endl;
         filteredTimesteps.push_back(t + 1);
         init->probablyMissingGRF[trial][t + 1] = true;
+        init->missingGRFReason[trial][t + 1] = MissingGRFReason::forceDiscrepancy;
       }
     }
     if (filteredTimesteps.size() > 0)
@@ -10254,6 +10265,7 @@ int DynamicsFitter::estimateUnmeasuredExternalTorques(
         if (init->probablyMissingGRF.size() > trial)
         {
           init->probablyMissingGRF[trial][t] = true;
+          init->missingGRFReason[trial][t] = MissingGRFReason::unmeasuredTorque;
         }
       }
       std::cout << "Ang badness " << t << ": " << badness << std::endl;
@@ -11874,9 +11886,11 @@ bool DynamicsFitter::timeSyncTrialGRF(
     originalMoments.push_back(moments);
   }
   std::vector<bool> originalProbablyMissingGRF;
+  std::vector<MissingGRFReason> originalMissingGRFReason;
   for (int t = 0; t < init->probablyMissingGRF[trial].size(); t++)
   {
     originalProbablyMissingGRF.push_back(init->probablyMissingGRF[trial][t]);
+    originalMissingGRFReason.push_back(init->missingGRFReason[trial][t]);
   }
 
   bool atLeastOneShiftSucceeded = false;
@@ -11908,12 +11922,14 @@ bool DynamicsFitter::timeSyncTrialGRF(
       {
         shiftedGRFTrial.col(t).setZero();
         init->probablyMissingGRF[trial][t] = true;
+        init->missingGRFReason[trial][t] = MissingGRFReason::shiftGRF;
       }
       else
       {
         shiftedGRFTrial.col(t) = originalGRFTrial.col(originalT);
         init->probablyMissingGRF[trial][t]
             = originalProbablyMissingGRF[originalT];
+        init->missingGRFReason[trial][t] = originalMissingGRFReason[originalT];
       }
     }
 
@@ -12064,12 +12080,14 @@ bool DynamicsFitter::timeSyncTrialGRF(
     if (originalT < 0 || originalT >= originalGRFTrial.cols())
     {
       init->probablyMissingGRF[trial][t] = true;
+      init->missingGRFReason[trial][t] = MissingGRFReason::shiftGRF;
     }
     else
     {
       init->probablyMissingGRF[trial][t]
           = originalProbablyMissingGRF[originalT];
-    }
+      init->missingGRFReason[trial][t] = originalMissingGRFReason[originalT];
+     }
   }
 
   // Return failure if no shifts succeed.
@@ -12157,6 +12175,7 @@ bool DynamicsFitter::timeSyncAndInitializePipeline(
   auto originalForcePlatesAssignedToContactBody =
       init->forcePlatesAssignedToContactBody;
   auto originalProbablyMissingGRF = init->probablyMissingGRF;
+  auto originalMissingGRFReason = init->missingGRFReason;
 
   // Get rid of the rest of the angular residuals
   bool residualMinimizationSuccess = true;
@@ -12214,6 +12233,7 @@ bool DynamicsFitter::timeSyncAndInitializePipeline(
     init->forcePlatesAssignedToContactBody =
         originalForcePlatesAssignedToContactBody;
     init->probablyMissingGRF = originalProbablyMissingGRF;
+    init->missingGRFReason = originalMissingGRFReason;
     return false;
   }
 
@@ -15204,6 +15224,7 @@ void DynamicsFitter::writeCSVData(
     csvFile << ",acc_" << mSkeleton->getDof(i)->getName();
   }
   csvFile << ",missing_grf_data";
+  csvFile << ",missing_grf_reason";
   for (int i = 0; i < mFootNodes.size(); i++)
   {
     csvFile << "," << mFootNodes[i]->getName() << "_probably_contacting_ground";
@@ -15263,7 +15284,7 @@ void DynamicsFitter::writeCSVData(
     Eigen::VectorXs dq = Eigen::VectorXs::Zero(q.size());
     Eigen::VectorXs ddq = Eigen::VectorXs::Zero(q.size());
     Eigen::VectorXs tau = Eigen::VectorXs::Zero(q.size());
-    if (t > 0 || t < nrows-1) {
+    if (t > 0 && t < nrows-1) {
       dq = (init->poseTrials[trial].col(t)
             - init->poseTrials[trial].col(t - 1))
            / dt;
@@ -15299,6 +15320,7 @@ void DynamicsFitter::writeCSVData(
     writeVectorToCSV(csvFile, tau);
     writeVectorToCSV(csvFile, ddq);
     csvFile << "," << init->probablyMissingGRF[trial][t];
+    csvFile << "," << init->missingGRFReason[trial][t];
     for (int i = 0; i < mFootNodes.size(); i++)
     {
       csvFile << "," << init->grfBodyForceActive[trial][t][i]
@@ -15356,6 +15378,7 @@ void DynamicsFitter::writeSubjectOnDisk(
   std::vector<Eigen::MatrixXs> trialGroundBodyWrenches;
   std::vector<Eigen::MatrixXs> trialGroundBodyCopTorqueForce;
   std::vector<std::vector<bool>> trialProbablyMissingGRF;
+  std::vector<std::vector<MissingGRFReason>> trialMissingGRFReason;
   std::vector<std::string> customValueNames;
   std::vector<std::vector<Eigen::MatrixXs>> customValues;
 
@@ -15381,6 +15404,7 @@ void DynamicsFitter::writeSubjectOnDisk(
     Eigen::MatrixXs bodyCopTorqueForce
         = Eigen::MatrixXs::Zero(groundContactBodyNames.size() * 9, timesteps);
     std::vector<bool> probablyMissingGRF;
+    std::vector<MissingGRFReason> missingGRFReason;
 
     for (int t = 1; t < init->poseTrials[trial].cols() - 1; t++)
     {
@@ -15450,6 +15474,7 @@ void DynamicsFitter::writeSubjectOnDisk(
       bodyCopTorqueForce.col(t - 1) = footContactData;
 
       probablyMissingGRF.push_back(init->probablyMissingGRF[trial][t]);
+      missingGRFReason.push_back(init->missingGRFReason[trial][t]);
     }
 
     trialPoses.push_back(poses);
@@ -15459,6 +15484,7 @@ void DynamicsFitter::writeSubjectOnDisk(
     trialGroundBodyWrenches.push_back(bodyWrenches);
     trialGroundBodyCopTorqueForce.push_back(bodyCopTorqueForce);
     trialProbablyMissingGRF.push_back(probablyMissingGRF);
+    trialMissingGRFReason.push_back(missingGRFReason);
   }
 
   SubjectOnDisk::writeSubject(
@@ -15469,6 +15495,7 @@ void DynamicsFitter::writeSubjectOnDisk(
       trialVels,
       trialAccs,
       trialProbablyMissingGRF,
+      trialMissingGRFReason,
       trialTaus,
       groundContactBodyNames,
       trialGroundBodyWrenches,

--- a/dart/biomechanics/DynamicsFitter.cpp
+++ b/dart/biomechanics/DynamicsFitter.cpp
@@ -9793,7 +9793,6 @@ void DynamicsFitter::estimateFootGroundContacts(
             contactIsSus = true;
             anyContactIsSus = true;
             reason = MissingGRFReason::notOverForcePlate;
-            std::cout << "DEBUG estimateFootGroundContacts: GRF and contact detected, but no force plate detected. Ignoring frame " << t << "..." << std::endl;
           }
         }
 
@@ -9861,9 +9860,9 @@ void DynamicsFitter::markMissingImpacts(
           int offsetT = t + i;
           if (offsetT < init->probablyMissingGRF[trial].size())
           {
-            std::cout << "DEBUG markMissingImpacts: impact or liftoff detected, but ??? on frame" << t << "..." << std::endl;
             init->probablyMissingGRF[trial][offsetT] = true;
-            init->missingGRFReason[trial][offsetT] = MissingGRFReason::missingImpact;
+            init->missingGRFReason[trial][offsetT] =
+                MissingGRFReason::missingImpact;
           }
         }
       }
@@ -9912,8 +9911,8 @@ void DynamicsFitter::fillInMissingGRFBlips(
             if (scanT < init->probablyMissingGRF[trial].size())
             {
               init->probablyMissingGRF[trial][scanT] = true;
-              init->missingGRFReason[trial][scanT] = MissingGRFReason::missingBlip;
-              std::cout << "DEBUG fillMissingGRFBlips: ??? on frame " << t << "..." << std::endl;
+              init->missingGRFReason[trial][scanT] =
+                  MissingGRFReason::missingBlip;
             }
           }
         }
@@ -10205,7 +10204,8 @@ void DynamicsFitter::estimateUnmeasuredExternalForces(
             << threshold << ")" << std::endl;
         filteredTimesteps.push_back(t + 1);
         init->probablyMissingGRF[trial][t + 1] = true;
-        init->missingGRFReason[trial][t + 1] = MissingGRFReason::forceDiscrepancy;
+        init->missingGRFReason[trial][t + 1] =
+            MissingGRFReason::forceDiscrepancy;
       }
     }
     if (filteredTimesteps.size() > 0)

--- a/dart/biomechanics/DynamicsFitter.cpp
+++ b/dart/biomechanics/DynamicsFitter.cpp
@@ -10153,7 +10153,8 @@ void DynamicsFitter::estimateUnmeasuredExternalForces(
                   << trial << " at time " << t << std::endl;
         filteredTimesteps.push_back(t + 1);
         init->probablyMissingGRF[trial][t + 1] = true;
-        init->missingGRFReason[trial][t + 1] = MissingGRFReason::unmeasuredForce;
+        init->missingGRFReason[trial][t + 1] =
+            MissingGRFReason::unmeasuredExternalForceDetected;
         continue;
       }
       else if (!isEstimatedZero && isMeasuredZero)
@@ -10164,7 +10165,8 @@ void DynamicsFitter::estimateUnmeasuredExternalForces(
                     << std::endl;
           filteredTimesteps.push_back(t + 1);
           init->probablyMissingGRF[trial][t + 1] = true;
-          init->missingGRFReason[trial][t + 1] = MissingGRFReason::missingGRF;
+          init->missingGRFReason[trial][t + 1] =
+              MissingGRFReason::measuredGrfZeroWhenAccelerationNonZero;
         }
         continue;
       }
@@ -10267,7 +10269,7 @@ int DynamicsFitter::estimateUnmeasuredExternalTorques(
         if (init->probablyMissingGRF.size() > trial)
         {
           init->probablyMissingGRF[trial][t] = true;
-          init->missingGRFReason[trial][t] = MissingGRFReason::unmeasuredTorque;
+          init->missingGRFReason[trial][t] = MissingGRFReason::torqueDiscrepancy;
         }
       }
       std::cout << "Ang badness " << t << ": " << badness << std::endl;

--- a/dart/biomechanics/DynamicsFitter.hpp
+++ b/dart/biomechanics/DynamicsFitter.hpp
@@ -1298,7 +1298,8 @@ public:
   // 0. Estimate when each foot is in contact with the ground, which we can use
   // to infer when we're missing GRF data on certain timesteps, so we don't let
   // it mess with our optimization.
-  void estimateFootGroundContacts(std::shared_ptr<DynamicsInitialization> init);
+  void estimateFootGroundContacts(std::shared_ptr<DynamicsInitialization> init,
+                                  bool allowSusContact = false);
 
   // 0. This goes through and marks any "impact" GRF timesteps (defined as
   // `windowLen` steps after the first non-zero step after a flight phase with
@@ -1370,6 +1371,7 @@ public:
   void multimassZeroLinearResidualsOnCOMTrajectory(
       std::shared_ptr<DynamicsInitialization> init,
       int maxTrialsToSolveMassOver = 4,
+      bool detectExternalForce = true,
       s_t boundPush = 0.01);
 
   // 1. Change the initial positions and velocities of the body to achieve a
@@ -1428,6 +1430,7 @@ public:
       s_t regularizeCopDriftCompensation = 1.0,
       int maxBuckets = 100,
       bool detectUnmeasuredTorque = true,
+      bool detectExternalForce = true,
       s_t avgPositionChangeThreshold = 0.08,
       s_t avgAngularChangeThreshold = 0.15);
 

--- a/dart/biomechanics/DynamicsFitter.hpp
+++ b/dart/biomechanics/DynamicsFitter.hpp
@@ -10,6 +10,7 @@
 
 #include "dart/biomechanics/ForcePlate.hpp"
 #include "dart/biomechanics/MarkerFitter.hpp"
+#include "dart/biomechanics/enums.hpp"
 #include "dart/dynamics/BodyNode.hpp"
 #include "dart/dynamics/Joint.hpp"
 #include "dart/dynamics/Skeleton.hpp"
@@ -770,6 +771,8 @@ protected:
   std::shared_ptr<dynamics::Skeleton> mSkel;
 };
 
+
+
 /**
  * We create a single initialization object, and pass it around to optimization
  * problems to re-use, because it's not super cheap to construct.
@@ -812,6 +815,7 @@ struct DynamicsInitialization
   // This is the critical value, telling us if we think we're receiving support
   // from off a force plate on this frame
   std::vector<std::vector<bool>> probablyMissingGRF;
+  std::vector<std::vector<MissingGRFReason>> missingGRFReason;
   // This is a map of [trial][forcePlate][timestep], where each force plate is
   // assigned to one of the contact bodies.
   std::vector<std::vector<std::vector<int>>> forcePlatesAssignedToContactBody;

--- a/dart/biomechanics/DynamicsFitter.hpp
+++ b/dart/biomechanics/DynamicsFitter.hpp
@@ -1302,7 +1302,7 @@ public:
   // 0. Estimate when each foot is in contact with the ground, which we can use
   // to infer when we're missing GRF data on certain timesteps, so we don't let
   // it mess with our optimization.
-  void estimateFootGroundContacts(std::shared_ptr<DynamicsInitialization>);
+  void estimateFootGroundContacts(std::shared_ptr<DynamicsInitialization> init);
 
   // 0. This goes through and marks any "impact" GRF timesteps (defined as
   // `windowLen` steps after the first non-zero step after a flight phase with
@@ -1432,7 +1432,6 @@ public:
       s_t regularizeCopDriftCompensation = 1.0,
       int maxBuckets = 100,
       bool detectUnmeasuredTorque = true,
-      bool detectExternalForce = true,
       s_t avgPositionChangeThreshold = 0.08,
       s_t avgAngularChangeThreshold = 0.15);
 

--- a/dart/biomechanics/DynamicsFitter.hpp
+++ b/dart/biomechanics/DynamicsFitter.hpp
@@ -1302,8 +1302,7 @@ public:
   // 0. Estimate when each foot is in contact with the ground, which we can use
   // to infer when we're missing GRF data on certain timesteps, so we don't let
   // it mess with our optimization.
-  void estimateFootGroundContacts(std::shared_ptr<DynamicsInitialization> init,
-                                  bool allowSusContact = false);
+  void estimateFootGroundContacts(std::shared_ptr<DynamicsInitialization>);
 
   // 0. This goes through and marks any "impact" GRF timesteps (defined as
   // `windowLen` steps after the first non-zero step after a flight phase with
@@ -1375,7 +1374,6 @@ public:
   void multimassZeroLinearResidualsOnCOMTrajectory(
       std::shared_ptr<DynamicsInitialization> init,
       int maxTrialsToSolveMassOver = 4,
-      bool detectExternalForce = true,
       s_t boundPush = 0.01);
 
   // 1. Change the initial positions and velocities of the body to achieve a

--- a/dart/biomechanics/SubjectOnDisk.hpp
+++ b/dart/biomechanics/SubjectOnDisk.hpp
@@ -9,6 +9,7 @@
 
 #include "dart/dynamics/Skeleton.hpp"
 #include "dart/math/MathTypes.hpp"
+#include "dart/biomechanics/enums.hpp"
 
 namespace dart {
 namespace biomechanics {
@@ -18,6 +19,7 @@ struct Frame
   int trial;
   int t;
   bool probablyMissingGRF;
+  MissingGRFReason missingGRFReason;
 
   Eigen::VectorXd pos;
   Eigen::VectorXd vel;
@@ -74,6 +76,7 @@ public:
       std::vector<Eigen::MatrixXs>& trialVels,
       std::vector<Eigen::MatrixXs>& trialAccs,
       std::vector<std::vector<bool>>& probablyMissingGRF,
+      std::vector<std::vector<MissingGRFReason>>& missingGRFReason,
       std::vector<Eigen::MatrixXs>& trialTaus,
       // These are generalized 6-dof wrenches applied to arbitrary bodies
       // (generally by foot-ground contact, though other things too)
@@ -103,6 +106,10 @@ public:
   /// heuristically detected to be missing external forces (which means that the
   /// inverse dynamics cannot be trusted).
   std::vector<bool> getProbablyMissingGRF(int trial);
+
+  /// This returns the vector of enums of type 'MissingGRFReason', which labels
+  /// why each time step was identified as 'probablyMissingGRF'.
+  std::vector<MissingGRFReason> getMissingGRFReason(int trial);
 
   /// This returns the list of contact body names for this Subject
   std::vector<std::string> getGroundContactBodies();
@@ -141,6 +148,7 @@ protected:
   // memory, but we really want to know this information when randomly picking
   // frames from the subject to sample.
   std::vector<std::vector<bool>> mProbablyMissingGRF;
+  std::vector<std::vector<MissingGRFReason>> mMissingGRFReason;
   // The trial names, if provided, or empty strings
   std::vector<std::string> mTrialNames;
   // An optional link to the web where this subject came from

--- a/dart/biomechanics/enums.hpp
+++ b/dart/biomechanics/enums.hpp
@@ -5,9 +5,9 @@ namespace dart {
 namespace biomechanics {
 
 enum MissingGRFReason { notMissingGRF,
-                        missingGRF,
-                        unmeasuredForce,
-                        unmeasuredTorque,
+                        measuredGrfZeroWhenAccelerationNonZero,
+                        unmeasuredExternalForceDetected,
+                        torqueDiscrepancy,
                         forceDiscrepancy,
                         notOverForcePlate,
                         missingImpact,

--- a/dart/biomechanics/enums.hpp
+++ b/dart/biomechanics/enums.hpp
@@ -1,0 +1,20 @@
+#ifndef BIOMECHANICS_ENUMS_HPP
+#define BIOMECHANICS_ENUMS_HPP
+
+namespace dart {
+namespace biomechanics {
+
+enum MissingGRFReason { notMissingGRF = 0,
+                        missingGRF = 1,
+                        unmeasuredForce = 2,
+                        unmeasuredTorque = 3,
+                        forceDiscrepancy = 4,
+                        notOverForcePlate = 5,
+                        missingImpact = 6,
+                        missingBlip = 7,
+                        shiftGRF = 8};
+
+}
+}
+
+#endif // BIOMECHANICS_ENUMS_HPP

--- a/dart/biomechanics/enums.hpp
+++ b/dart/biomechanics/enums.hpp
@@ -4,15 +4,15 @@
 namespace dart {
 namespace biomechanics {
 
-enum MissingGRFReason { notMissingGRF = 0,
-                        missingGRF = 1,
-                        unmeasuredForce = 2,
-                        unmeasuredTorque = 3,
-                        forceDiscrepancy = 4,
-                        notOverForcePlate = 5,
-                        missingImpact = 6,
-                        missingBlip = 7,
-                        shiftGRF = 8};
+enum MissingGRFReason { notMissingGRF,
+                        missingGRF,
+                        unmeasuredForce,
+                        unmeasuredTorque,
+                        forceDiscrepancy,
+                        notOverForcePlate,
+                        missingImpact,
+                        missingBlip,
+                        shiftGRF};
 
 }
 }

--- a/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
+++ b/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
@@ -531,7 +531,8 @@ protected:
       .def(
           "estimateFootGroundContacts",
           &dart::biomechanics::DynamicsFitter::estimateFootGroundContacts,
-          ::py::arg("init"))
+          ::py::arg("init"),
+          ::py::arg("allowSusContact") = false)
       .def(
           "smoothAccelerations",
           &dart::biomechanics::DynamicsFitter::smoothAccelerations,
@@ -570,6 +571,7 @@ protected:
               multimassZeroLinearResidualsOnCOMTrajectory,
           ::py::arg("init"),
           ::py::arg("maxTrialsToSolveMassOver") = 4,
+          ::py::arg("detectExternalForce") = true,
           ::py::arg("boundPush") = 0.01)
       .def(
           "zeroLinearResidualsAndOptimizeAngular",
@@ -622,6 +624,7 @@ protected:
           ::py::arg("regularizeCopDriftCompensation") = 1.0,
           ::py::arg("maxBuckets") = 100,
           ::py::arg("detectUnmeasuredTorque") = true,
+          ::py::arg("detectExternalForce") = true,
           ::py::arg("avgPositionChangeThreshold") = 0.08,
           ::py::arg("avgAngularChangeThreshold") = 0.15)
       .def(

--- a/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
+++ b/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
@@ -622,7 +622,6 @@ protected:
           ::py::arg("regularizeCopDriftCompensation") = 1.0,
           ::py::arg("maxBuckets") = 100,
           ::py::arg("detectUnmeasuredTorque") = true,
-          ::py::arg("detectExternalForce") = true,
           ::py::arg("avgPositionChangeThreshold") = 0.08,
           ::py::arg("avgAngularChangeThreshold") = 0.15)
       .def(

--- a/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
+++ b/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
@@ -531,8 +531,7 @@ protected:
       .def(
           "estimateFootGroundContacts",
           &dart::biomechanics::DynamicsFitter::estimateFootGroundContacts,
-          ::py::arg("init"),
-          ::py::arg("allowSusContact") = false)
+          ::py::arg("init"))
       .def(
           "smoothAccelerations",
           &dart::biomechanics::DynamicsFitter::smoothAccelerations,
@@ -571,7 +570,6 @@ protected:
               multimassZeroLinearResidualsOnCOMTrajectory,
           ::py::arg("init"),
           ::py::arg("maxTrialsToSolveMassOver") = 4,
-          ::py::arg("detectExternalForce") = true,
           ::py::arg("boundPush") = 0.01)
       .def(
           "zeroLinearResidualsAndOptimizeAngular",

--- a/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
+++ b/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
@@ -258,7 +258,27 @@ Note that these are specified in the local body frame, acting on the body at its
         until asked for. That way we can instantiate thousands of these in memory,
         and not worry about OOM'ing a machine.
       )doc";
-}
 
+  py::enum_<dart::biomechanics::MissingGRFReason>(subjectOnDisk, "MissingGRFReason")
+      .value("notMissingGRF",
+             dart::biomechanics::MissingGRFReason::notMissingGRF)
+      .value("measuredGrfZeroWhenAccelerationNonZero",
+             dart::biomechanics::MissingGRFReason::measuredGrfZeroWhenAccelerationNonZero)
+      .value("unmeasuredExternalForceDetected",
+             dart::biomechanics::MissingGRFReason::unmeasuredExternalForceDetected)
+      .value("torqueDiscrepancy",
+             dart::biomechanics::MissingGRFReason::torqueDiscrepancy)
+      .value("forceDiscrepancy",
+             dart::biomechanics::MissingGRFReason::forceDiscrepancy)
+      .value("notOverForcePlate",
+             dart::biomechanics::MissingGRFReason::notOverForcePlate)
+      .value("missingImpact",
+             dart::biomechanics::MissingGRFReason::missingImpact)
+      .value("missingBlip",
+             dart::biomechanics::MissingGRFReason::missingBlip)
+      .value("shiftGRF",
+             dart::biomechanics::MissingGRFReason::shiftGRF)
+      .export_values();
+}
 } // namespace python
 } // namespace dart

--- a/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
+++ b/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
@@ -113,6 +113,31 @@ Note that these are specified in the local body frame, acting on the body at its
         This is for doing ML and large-scale data analysis. This is a single frame of data, returned in a list by :code:`SubjectOnDisk.readFrames()`, which contains everything needed to reconstruct all the dynamics of a snapshot in time.
       )doc";
 
+  py::enum_<dart::biomechanics::MissingGRFReason>(m, "MissingGRFReason")
+      .value(
+          "notMissingGRF", dart::biomechanics::MissingGRFReason::notMissingGRF)
+      .value(
+          "measuredGrfZeroWhenAccelerationNonZero",
+          dart::biomechanics::MissingGRFReason::
+              measuredGrfZeroWhenAccelerationNonZero)
+      .value(
+          "unmeasuredExternalForceDetected",
+          dart::biomechanics::MissingGRFReason::unmeasuredExternalForceDetected)
+      .value(
+          "torqueDiscrepancy",
+          dart::biomechanics::MissingGRFReason::torqueDiscrepancy)
+      .value(
+          "forceDiscrepancy",
+          dart::biomechanics::MissingGRFReason::forceDiscrepancy)
+      .value(
+          "notOverForcePlate",
+          dart::biomechanics::MissingGRFReason::notOverForcePlate)
+      .value(
+          "missingImpact", dart::biomechanics::MissingGRFReason::missingImpact)
+      .value("missingBlip", dart::biomechanics::MissingGRFReason::missingBlip)
+      .value("shiftGRF", dart::biomechanics::MissingGRFReason::shiftGRF)
+      .export_values();
+
   auto subjectOnDisk
       = ::py::class_<
             dart::biomechanics::SubjectOnDisk,
@@ -258,27 +283,6 @@ Note that these are specified in the local body frame, acting on the body at its
         until asked for. That way we can instantiate thousands of these in memory,
         and not worry about OOM'ing a machine.
       )doc";
-
-  py::enum_<dart::biomechanics::MissingGRFReason>(subjectOnDisk, "MissingGRFReason")
-      .value("notMissingGRF",
-             dart::biomechanics::MissingGRFReason::notMissingGRF)
-      .value("measuredGrfZeroWhenAccelerationNonZero",
-             dart::biomechanics::MissingGRFReason::measuredGrfZeroWhenAccelerationNonZero)
-      .value("unmeasuredExternalForceDetected",
-             dart::biomechanics::MissingGRFReason::unmeasuredExternalForceDetected)
-      .value("torqueDiscrepancy",
-             dart::biomechanics::MissingGRFReason::torqueDiscrepancy)
-      .value("forceDiscrepancy",
-             dart::biomechanics::MissingGRFReason::forceDiscrepancy)
-      .value("notOverForcePlate",
-             dart::biomechanics::MissingGRFReason::notOverForcePlate)
-      .value("missingImpact",
-             dart::biomechanics::MissingGRFReason::missingImpact)
-      .value("missingBlip",
-             dart::biomechanics::MissingGRFReason::missingBlip)
-      .value("shiftGRF",
-             dart::biomechanics::MissingGRFReason::shiftGRF)
-      .export_values();
 }
 } // namespace python
 } // namespace dart

--- a/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
+++ b/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
@@ -160,6 +160,7 @@ Note that these are specified in the local body frame, acting on the body at its
                 ::py::arg("trialVels"),
                 ::py::arg("trialAccs"),
                 ::py::arg("probablyMissingGRF"),
+                ::py::arg("missingGRFReason"),
                 ::py::arg("trialTaus"),
                 // These are generalized 6-dof wrenches applied to arbitrary
                 // bodies (generally by foot-ground contact, though other things
@@ -205,6 +206,14 @@ Note that these are specified in the local body frame, acting on the body at its
 
             This method is provided to give a cheaper way to filter out frames we want to ignore for training, without having to call
             the more expensive :code:`loadFrames()`
+          )doc")
+            .def(
+                "getMissingGRFReason",
+                &dart::biomechanics::SubjectOnDisk::getMissingGRFReason,
+                ::py::arg("trial"),
+                R"doc(
+            This returns an array of enum values, one per frame in the specified trial,
+            each corresponding to the reason why a frame was marked as `probablyMissingGRF`.
           )doc")
             .def(
                 "getTrialName",

--- a/unittests/unit/test_SubjectOnDisk.cpp
+++ b/unittests/unit/test_SubjectOnDisk.cpp
@@ -160,6 +160,7 @@ bool testWriteSubjectToDisk(
         grfReason.push_back(MissingGRFReason::notMissingGRF);
       }
     }
+    missingGRFReason.push_back(grfReason);
     probablyMissingGRFData.push_back(missingGRF);
   }
 
@@ -250,6 +251,12 @@ bool testWriteSubjectToDisk(
       if (frame->probablyMissingGRF != probablyMissingGRFData[trial][frame->t])
       {
         std::cout << "missing GRF not recovered" << std::endl;
+        return false;
+      }
+
+      if (frame->missingGRFReason != missingGRFReason[trial][frame->t])
+      {
+        std::cout << "missing GRF reason not recovered" << std::endl;
         return false;
       }
 

--- a/unittests/unit/test_SubjectOnDisk.cpp
+++ b/unittests/unit/test_SubjectOnDisk.cpp
@@ -64,6 +64,7 @@ bool testWriteSubjectToDisk(
   std::vector<Eigen::MatrixXs> groundBodyWrenchTrials;
   std::vector<Eigen::MatrixXs> groundBodyCopTorqueForceTrials;
   std::vector<std::vector<bool>> probablyMissingGRFData;
+  std::vector<std::vector<MissingGRFReason>> missingGRFReason;
   std::vector<std::string> customValueNames;
   std::vector<std::vector<Eigen::MatrixXs>> customValueTrials;
 
@@ -149,9 +150,15 @@ bool testWriteSubjectToDisk(
     customValueTrials.push_back(trialCustomValues);
 
     std::vector<bool> missingGRF;
+    std::vector<MissingGRFReason> grfReason;
     for (int t = 0; t < poseTrials[trial].cols(); t++)
     {
       missingGRF.push_back(t % 10 == 0);
+      if (t % 10 == 0) {
+        grfReason.push_back(MissingGRFReason::missingGRF);
+      } else {
+        grfReason.push_back(MissingGRFReason::notMissingGRF);
+      }
     }
     probablyMissingGRFData.push_back(missingGRF);
   }
@@ -176,6 +183,7 @@ bool testWriteSubjectToDisk(
       velTrials,
       accTrials,
       probablyMissingGRFData,
+      missingGRFReason,
       tauTrials,
       groundForceBodies,
       groundBodyWrenchTrials,


### PR DESCRIPTION
This PR adds the new enum `MissingGRFReason`, which will let us keep track of why a frame was marked as "possiblyMissingGRF". I think I covered all of the possible cases, but feel free to point out any other that I might have missed. 

I mostly need feedback on the changes to `SubjectOnDisk`, some of that code was a little unclear to me. Specifically, should I make any additions here?

https://github.com/keenon/nimblephysics/blob/8ebc50ade44a0a659e1f945334b9bdc3a2b9c71d/stubs/_nimblephysics-stubs/biomechanics/__init__.pyi#L326

There is also a small fix in `writeCSVData()`, where I messed up printing out the time column.
