### PR TITLE
IMU support

### DIFF
--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -7570,8 +7570,8 @@ std::map<std::string, Eigen::Vector3s> Skeleton::getGyroMapReadings(
 }
 
 //==============================================================================
-/// These are a set of bodies, and offsets in local body space where gyros
-/// are mounted on the body
+/// These are a set of bodies, and offsets in local body space where
+/// accelerometers are mounted on the body
 std::map<std::string, Eigen::Vector3s> Skeleton::getAccMapReadings(
     const SensorMap& accs)
 {

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -63,6 +63,9 @@ namespace dynamics {
 typedef std::map<std::string, std::pair<dynamics::BodyNode*, Eigen::Vector3s>>
     MarkerMap;
 
+typedef std::map<std::string, std::pair<dynamics::BodyNode*, Eigen::Isometry3s>>
+    SensorMap;
+
 struct BodyScaleGroup
 {
   std::vector<dynamics::BodyNode*> nodes;
@@ -1568,6 +1571,62 @@ public:
       bool scaleBodies = false,
       math::IKConfig config = math::IKConfig());
 
+  /// These are a set of bodies, and offsets in local body space where gyros
+  /// are mounted on the body
+  std::map<std::string, Eigen::Vector3s> getGyroMapReadings(
+      const SensorMap& gyros);
+
+  /// These are a set of bodies, and offsets in local body space where gyros
+  /// are mounted on the body
+  std::map<std::string, Eigen::Vector3s> getAccMapReadings(
+      const SensorMap& accs);
+
+  /// This converts markers from a source skeleton to the current, doing a
+  /// simple mapping based on body node names. Any markers that don't find a
+  /// body node in the current skeleton with the same name are dropped.
+  SensorMap convertSensorMap(
+      const SensorMap& sensorMap, bool warnOnDrop = true);
+
+  /// These are a set of bodies, and offsets in local body space where gyros
+  /// are mounted on the body
+  Eigen::VectorXs getGyroReadings(
+      const std::vector<std::pair<dynamics::BodyNode*, Eigen::Isometry3s>>&
+          gyros);
+
+  /// This returns the Jacobian relating changes in joint
+  /// positions to changes in gyro readings
+  Eigen::MatrixXs getGyroReadingsJacobianWrt(
+      const std::vector<std::pair<dynamics::BodyNode*, Eigen::Isometry3s>>&
+          gyros,
+      neural::WithRespectTo* wrt);
+
+  /// This returns the Jacobian relating changes in joint
+  /// positions to changes in gyro readings
+  Eigen::MatrixXs finiteDifferenceGyroReadingsJacobianWrt(
+      const std::vector<std::pair<dynamics::BodyNode*, Eigen::Isometry3s>>&
+          gyros,
+      neural::WithRespectTo* wrt);
+
+  /// These are a set of bodies, and offsets in local body space where accs
+  /// are mounted on the body
+  Eigen::VectorXs getAccelerometerReadings(
+      const std::vector<std::pair<dynamics::BodyNode*, Eigen::Isometry3s>>&
+          accs);
+
+  /// This returns the Jacobian relating changes in joint
+  /// positions to changes in acc readings
+  Eigen::MatrixXs getAccelerometerReadingsJacobianWrt(
+      const std::vector<std::pair<dynamics::BodyNode*, Eigen::Isometry3s>>&
+          accs,
+      neural::WithRespectTo* wrt);
+
+  /// This returns the Jacobian relating changes in joint
+  /// positions to changes in acc readings
+  Eigen::MatrixXs finiteDifferenceAccelerometerReadingsJacobianWrt(
+      const std::vector<std::pair<dynamics::BodyNode*, Eigen::Isometry3s>>&
+          accs,
+      neural::WithRespectTo* wrt);
+
   //----------------------------------------------------------------------------
   // Handling anthropometric measurements
   //----------------------------------------------------------------------------
@@ -1616,6 +1675,30 @@ public:
   //----------------------------------------------------------------------------
   // Handling translation of velocities and accelerations into body space
   //----------------------------------------------------------------------------
+
+  /// This returns the spatial velocities (6 vecs) of the bodies each in local
+  /// body space, concatenated
+  Eigen::VectorXs getBodyLocalVelocities();
+
+  /// This returns the spatial accelerations (6 vecs) of the bodies in each in
+  /// local body space, concatenated
+  Eigen::VectorXs getBodyLocalAccelerations();
+
+  /// This computes the jacobian of the local velocities for each body with
+  /// respect to `wrt`
+  Eigen::MatrixXs getBodyLocalVelocitiesJacobian(neural::WithRespectTo* wrt);
+
+  /// This brute forces our local velocities jacobian
+  Eigen::MatrixXs finiteDifferenceBodyLocalVelocitiesJacobian(
+      neural::WithRespectTo* wrt);
+
+  /// This computes the jacobian of the local accelerations for each body with
+  /// respect to `wrt`
+  Eigen::MatrixXs getBodyLocalAccelerationsJacobian(neural::WithRespectTo* wrt);
+
+  /// This brute forces our local accelerations jacobian
+  Eigen::MatrixXs finiteDifferenceBodyLocalAccelerationsJacobian(
+      neural::WithRespectTo* wrt);
 
   /// This returns the spatial velocities (6 vecs) of the bodies in world space,
   /// concatenated

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -1576,8 +1576,8 @@ public:
   std::map<std::string, Eigen::Vector3s> getGyroMapReadings(
       const SensorMap& gyros);
 
-  /// These are a set of bodies, and offsets in local body space where gyros
-  /// are mounted on the body
+  /// These are a set of bodies, and offsets in local body space where
+  /// accelerometers are mounted on the body
   std::map<std::string, Eigen::Vector3s> getAccMapReadings(
       const SensorMap& accs);
 

--- a/dart/neural/WithRespectTo.cpp
+++ b/dart/neural/WithRespectTo.cpp
@@ -96,7 +96,7 @@ WithRespectToVelocity::WithRespectToVelocity()
 /// A printable name for this WRT object
 std::string WithRespectToVelocity::name()
 {
-  return "VELOCUTY";
+  return "VELOCITY";
 }
 
 /// This returns this WRT from the world as a vector

--- a/python/_nimblephysics/dynamics/Skeleton.cpp
+++ b/python/_nimblephysics/dynamics/Skeleton.cpp
@@ -1025,6 +1025,62 @@ void Skeleton(
           ::py::arg("lineSearch") = true,
           ::py::arg("logOutput") = false)
       .def(
+          "getGyroMapReadings",
+          &dart::dynamics::Skeleton::getGyroMapReadings,
+          ::py::arg("gyros"),
+          R"docs(
+These are a set of bodies, and offsets in local body space where gyros
+are mounted on the body
+    )docs")
+      .def(
+          "getAccMapReadings",
+          &dart::dynamics::Skeleton::getAccMapReadings,
+          ::py::arg("accelerometers"),
+          R"docs(
+These are a set of bodies, and offsets in local body space where gyros
+are mounted on the body
+    )docs")
+      .def(
+          "convertSensorMap",
+          &dart::dynamics::Skeleton::convertSensorMap,
+          ::py::arg("sensorMap"),
+          ::py::arg("warnOnDrop") = true,
+          R"docs(
+This converts markers from a source skeleton to the current, doing a
+simple mapping based on body node names. Any markers that don't find a
+body node in the current skeleton with the same name are dropped.
+    )docs")
+      .def(
+          "getGyroReadings",
+          &dart::dynamics::Skeleton::getGyroMapReadings,
+          ::py::arg("gyros"),
+          R"docs(
+These are a set of bodies, and offsets in local body space where gyros are mounted on the body.
+    )docs")
+      .def(
+          "getGyroReadingsJacobianWrt",
+          &dart::dynamics::Skeleton::getGyroReadingsJacobianWrt,
+          ::py::arg("gyros"),
+          ::py::arg("wrt"),
+          R"docs(
+This returns the Jacobian relating changes in the `wrt` quantity to changes in gyro readings.
+    )docs")
+      .def(
+          "getAccelerometerReadings",
+          &dart::dynamics::Skeleton::getAccelerometerReadings,
+          ::py::arg("accelerometers"),
+          R"docs(
+These are a set of bodies, and offsets in local body space where accs are mounted on the body.
+    )docs")
+      .def(
+          "getAccelerometerReadingsJacobianWrt",
+          &dart::dynamics::Skeleton::getAccelerometerReadingsJacobianWrt,
+          ::py::arg("accs"),
+          ::py::arg("wrt"),
+          R"docs(
+This returns the Jacobian relating changes in the `wrt` quantity to changes in acc readings.
+    )docs")
+      .def(
           "setVelocityUpperLimits",
           +[](dart::dynamics::Skeleton* self, Eigen::VectorXs limits) -> void {
             self->setVelocityUpperLimits(limits);

--- a/python/_nimblephysics/nimblephysics.cpp
+++ b/python/_nimblephysics/nimblephysics.cpp
@@ -33,6 +33,8 @@
 #include <dart/config.hpp>
 #include <pybind11/pybind11.h>
 
+#include "dart/neural/WithRespectTo.hpp"
+
 namespace py = pybind11;
 
 namespace dart {
@@ -47,7 +49,10 @@ void dart_collision(py::module& m);
 void dart_constraint(py::module& m);
 void dart_simulation(py::module& m);
 void dart_utils(py::module& m);
-void dart_simulation_and_neural(py::module& m);
+void dart_simulation_and_neural(
+    py::module& m,
+    py::module& neural,
+    ::py::class_<dart::neural::WithRespectTo>& withRespectTo);
 void dart_trajectory(py::module& m);
 void dart_performance(py::module& m);
 void dart_realtime(py::module& m);
@@ -58,6 +63,10 @@ PYBIND11_MODULE(_nimblephysics, m)
 {
   m.doc() = "nimblephysics: Python API of Nimble";
 
+  auto neural = m.def_submodule("neural");
+  auto withRespectTo
+      = ::py::class_<dart::neural::WithRespectTo>(neural, "WithRespectTo");
+
   eigen_geometry(m);
 
   dart_common(m);
@@ -66,7 +75,7 @@ PYBIND11_MODULE(_nimblephysics, m)
   dart_dynamics(m);
   dart_collision(m);
   dart_constraint(m);
-  dart_simulation_and_neural(m);
+  dart_simulation_and_neural(m, neural, withRespectTo);
   dart_utils(m);
   dart_trajectory(m);
   dart_realtime(m);

--- a/python/_nimblephysics/simulation_and_neural/WithRespectTo.cpp
+++ b/python/_nimblephysics/simulation_and_neural/WithRespectTo.cpp
@@ -45,10 +45,10 @@ namespace py = pybind11;
 namespace dart {
 namespace python {
 
-void WithRespectTo(py::module& m)
+void WithRespectTo(
+    py::module& m, ::py::class_<dart::neural::WithRespectTo>& WithRespectTo)
 {
-  ::py::class_<dart::neural::WithRespectTo>(m, "WithRespectTo")
-      .def("name", &dart::neural::WithRespectTo::name)
+  WithRespectTo.def("name", &dart::neural::WithRespectTo::name)
       .def(
           "get",
           +[](dart::neural::WithRespectTo* self, simulation::World* world)

--- a/python/_nimblephysics/simulation_and_neural/module.cpp
+++ b/python/_nimblephysics/simulation_and_neural/module.cpp
@@ -42,7 +42,8 @@ namespace dart {
 namespace python {
 
 // Neural
-void WithRespectTo(py::module& sm);
+void WithRespectTo(
+    py::module& sm, ::py::class_<dart::neural::WithRespectTo>& withRespectTo);
 void WithRespectToMass(py::module& sm);
 void NeuralUtils(py::module& sm);
 void NeuralGlobalMethods(py::module& sm);
@@ -59,10 +60,12 @@ void World(
         dart::simulation::World,
         std::shared_ptr<dart::simulation::World>>& world);
 
-void dart_simulation_and_neural(py::module& m)
+void dart_simulation_and_neural(
+    py::module& m,
+    py::module& neural,
+    ::py::class_<dart::neural::WithRespectTo>& withRespectTo)
 {
   auto simulation = m.def_submodule("simulation");
-  auto neural = m.def_submodule("neural");
 
   neural.doc()
       = "This provides gradients to DART, with an eye on embedding DART as a "
@@ -73,7 +76,7 @@ void dart_simulation_and_neural(py::module& m)
           simulation, "World");
 
   NeuralUtils(neural);
-  WithRespectTo(neural);
+  WithRespectTo(neural, withRespectTo);
   WithRespectToMass(neural);
   Mapping(neural);
   IKMapping(neural);

--- a/stubs/_nimblephysics-stubs/dynamics/__init__.pyi
+++ b/stubs/_nimblephysics-stubs/dynamics/__init__.pyi
@@ -3,6 +3,7 @@ import nimblephysics_libs._nimblephysics.dynamics
 import typing
 import nimblephysics_libs._nimblephysics.common
 import nimblephysics_libs._nimblephysics.math
+import nimblephysics_libs._nimblephysics.neural
 import numpy
 _Shape = typing.Tuple[int, ...]
 
@@ -4397,6 +4398,13 @@ class Skeleton(MetaSkeleton):
     def computeKineticEnergy(self) -> float: ...
     def computePotentialEnergy(self) -> float: ...
     def convertMarkerMap(self, markerMap: typing.Dict[str, typing.Tuple[BodyNode, numpy.ndarray[numpy.float64, _Shape[3, 1]]]], warnOnDrop: bool = True) -> typing.Dict[str, typing.Tuple[BodyNode, numpy.ndarray[numpy.float64, _Shape[3, 1]]]]: ...
+    def convertSensorMap(self, sensorMap: typing.Dict[str, typing.Tuple[BodyNode, nimblephysics_libs._nimblephysics.math.Isometry3]], warnOnDrop: bool = True) -> typing.Dict[str, typing.Tuple[BodyNode, nimblephysics_libs._nimblephysics.math.Isometry3]]: 
+        """
+        This converts markers from a source skeleton to the current, doing a
+        simple mapping based on body node names. Any markers that don't find a
+        body node in the current skeleton with the same name are dropped.
+            
+        """
     @typing.overload
     def createBallJointAndBodyNodePair(self) -> typing.Tuple[BallJoint, BodyNode]: ...
     @typing.overload
@@ -4493,6 +4501,22 @@ class Skeleton(MetaSkeleton):
     def enableSelfCollisionCheck(self) -> None: ...
     def fitJointsToWorldPositions(self, positionJoints: typing.List[Joint], targetPositions: numpy.ndarray[numpy.float64, _Shape[m, 1]], scaleBodies: bool = False, convergenceThreshold: float = 1e-07, maxStepCount: int = 100, leastSquaresDamping: float = 0.01, lineSearch: bool = True, logOutput: bool = False) -> float: ...
     def fitMarkersToWorldPositions(self, markers: typing.List[typing.Tuple[BodyNode, numpy.ndarray[numpy.float64, _Shape[3, 1]]]], targetPositions: numpy.ndarray[numpy.float64, _Shape[m, 1]], markerWeights: numpy.ndarray[numpy.float64, _Shape[m, 1]], scaleBodies: bool = False, convergenceThreshold: float = 1e-07, maxStepCount: int = 100, leastSquaresDamping: float = 0.01, lineSearch: bool = True, logOutput: bool = False) -> float: ...
+    def getAccMapReadings(self, accelerometers: typing.Dict[str, typing.Tuple[BodyNode, nimblephysics_libs._nimblephysics.math.Isometry3]]) -> typing.Dict[str, numpy.ndarray[numpy.float64, _Shape[3, 1]]]: 
+        """
+        These are a set of bodies, and offsets in local body space where gyros
+        are mounted on the body
+            
+        """
+    def getAccelerometerReadings(self, accelerometers: typing.List[typing.Tuple[BodyNode, nimblephysics_libs._nimblephysics.math.Isometry3]]) -> numpy.ndarray[numpy.float64, _Shape[m, 1]]: 
+        """
+        These are a set of bodies, and offsets in local body space where accs are mounted on the body.
+            
+        """
+    def getAccelerometerReadingsJacobianWrt(self, accs: typing.List[typing.Tuple[BodyNode, nimblephysics_libs._nimblephysics.math.Isometry3]], wrt: nimblephysics_libs._nimblephysics.neural.WithRespectTo) -> numpy.ndarray[numpy.float64, _Shape[m, n]]: 
+        """
+        This returns the Jacobian relating changes in the `wrt` quantity to changes in acc readings.
+            
+        """
     def getAdjacentBodyCheck(self) -> bool: ...
     @typing.overload
     def getAngularJacobian(self, node: JacobianNode) -> numpy.ndarray[numpy.float64, _Shape[3, n]]: ...
@@ -4601,6 +4625,22 @@ class Skeleton(MetaSkeleton):
     def getGroupMassesUpperBound(self) -> numpy.ndarray[numpy.float64, _Shape[m, 1]]: ...
     def getGroupScaleDim(self) -> int: ...
     def getGroupScales(self) -> numpy.ndarray[numpy.float64, _Shape[m, 1]]: ...
+    def getGyroMapReadings(self, gyros: typing.Dict[str, typing.Tuple[BodyNode, nimblephysics_libs._nimblephysics.math.Isometry3]]) -> typing.Dict[str, numpy.ndarray[numpy.float64, _Shape[3, 1]]]: 
+        """
+        These are a set of bodies, and offsets in local body space where gyros
+        are mounted on the body
+            
+        """
+    def getGyroReadings(self, gyros: typing.Dict[str, typing.Tuple[BodyNode, nimblephysics_libs._nimblephysics.math.Isometry3]]) -> typing.Dict[str, numpy.ndarray[numpy.float64, _Shape[3, 1]]]: 
+        """
+        These are a set of bodies, and offsets in local body space where gyros are mounted on the body.
+            
+        """
+    def getGyroReadingsJacobianWrt(self, gyros: typing.List[typing.Tuple[BodyNode, nimblephysics_libs._nimblephysics.math.Isometry3]], wrt: nimblephysics_libs._nimblephysics.neural.WithRespectTo) -> numpy.ndarray[numpy.float64, _Shape[m, n]]: 
+        """
+        This returns the Jacobian relating changes in the `wrt` quantity to changes in gyro readings.
+            
+        """
     def getHeight(self, pos: numpy.ndarray[numpy.float64, _Shape[m, 1]], up: numpy.ndarray[numpy.float64, _Shape[3, 1]] = array([0., 1., 0.])) -> float: ...
     @typing.overload
     def getIndexOf(self, bn: BodyNode) -> int: ...

--- a/unittests/unit/CMakeLists.txt
+++ b/unittests/unit/CMakeLists.txt
@@ -184,6 +184,10 @@ if(TARGET dart-utils-urdf)
   target_link_libraries(test_BodySpatialTranslation dart-utils)
   target_link_libraries(test_BodySpatialTranslation dart-utils-urdf)
 
+  dart_add_test("unit" test_DifferentiableIMUs)
+  target_link_libraries(test_DifferentiableIMUs dart-utils)
+  target_link_libraries(test_DifferentiableIMUs dart-utils-urdf)
+
   dart_add_test("unit" test_DifferentiableExternalForce)
   target_link_libraries(test_DifferentiableExternalForce dart-utils)
   target_link_libraries(test_DifferentiableExternalForce dart-utils-urdf)

--- a/unittests/unit/test_DifferentiableIMUs.cpp
+++ b/unittests/unit/test_DifferentiableIMUs.cpp
@@ -1,0 +1,307 @@
+#include <algorithm> // std::sort
+#include <memory>
+#include <vector>
+
+#include <Eigen/Dense>
+#include <ccd/ccd.h>
+#include <gtest/gtest.h>
+#include <math.h>
+
+#include "dart/biomechanics/Anthropometrics.hpp"
+#include "dart/biomechanics/OpenSimParser.hpp"
+#include "dart/common/LocalResourceRetriever.hpp"
+#include "dart/common/ResourceRetriever.hpp"
+#include "dart/common/Uri.hpp"
+#include "dart/dynamics/BodyNode.hpp"
+#include "dart/dynamics/EulerFreeJoint.hpp"
+#include "dart/dynamics/Joint.hpp"
+#include "dart/dynamics/RevoluteJoint.hpp"
+#include "dart/dynamics/Skeleton.hpp"
+#include "dart/math/MathTypes.hpp"
+#include "dart/neural/WithRespectTo.hpp"
+#include "dart/realtime/Ticker.hpp"
+#include "dart/server/GUIWebsocketServer.hpp"
+#include "dart/utils/C3D.hpp"
+#include "dart/utils/CompositeResourceRetriever.hpp"
+#include "dart/utils/DartResourceRetriever.hpp"
+#include "dart/utils/PackageResourceRetriever.hpp"
+
+#include "GradientTestUtils.hpp"
+#include "TestHelpers.hpp"
+
+using namespace dart;
+using namespace biomechanics;
+
+#define ALL_TESTS
+
+bool verifyIMUJacobians(
+    std::shared_ptr<dynamics::Skeleton> skel, neural::WithRespectTo* wrt)
+{
+  srand(42);
+
+  std::vector<std::pair<dynamics::BodyNode*, Eigen::Isometry3s>> sensors;
+  for (int i = 0; i < skel->getNumBodyNodes(); i++)
+  {
+    sensors.emplace_back(skel->getBodyNode(i), Eigen::Isometry3s::Identity());
+    Eigen::Isometry3s T = Eigen::Isometry3s::Identity();
+    T.translation() = Eigen::Vector3s::Ones();
+    sensors.emplace_back(skel->getBodyNode(i), T);
+    Eigen::Isometry3s T2 = Eigen::Isometry3s::Identity();
+    T2.linear() = math::expMapRot(Eigen::Vector3s::Ones());
+    sensors.emplace_back(skel->getBodyNode(i), T2);
+    Eigen::Isometry3s T3 = Eigen::Isometry3s::Identity();
+    T3.translation() = Eigen::Vector3s::Random();
+    T3.linear() = math::expMapRot(Eigen::Vector3s::Random());
+    sensors.emplace_back(skel->getBodyNode(i), T3);
+  }
+
+  for (int i = 0; i < 10; i++)
+  {
+    skel->setPositions(Eigen::VectorXs::Random(skel->getNumDofs()));
+    skel->setVelocities(Eigen::VectorXs::Random(skel->getNumDofs()));
+    skel->setAccelerations(Eigen::VectorXs::Random(skel->getNumDofs()));
+
+    Eigen::MatrixXs velJ_fd
+        = skel->finiteDifferenceBodyLocalVelocitiesJacobian(wrt);
+    Eigen::MatrixXs velJ = skel->getBodyLocalVelocitiesJacobian(wrt);
+
+    if (!equals(velJ, velJ_fd, 1e-8))
+    {
+      std::cout << "Vel wrt " << wrt->name() << " error!" << std::endl;
+      for (int body = 0; body < velJ.rows() / 6; body++)
+      {
+        for (int dof = 0; dof < velJ.cols(); dof++)
+        {
+          Eigen::Vector6s analytical = velJ.block<6, 1>(body * 6, dof);
+          Eigen::Vector6s fd = velJ_fd.block<6, 1>(body * 6, dof);
+          if (!equals(analytical, fd, 1e-8))
+          {
+            std::cout << "Body \"" << skel->getBodyNode(body)->getName()
+                      << "\" disagrees on DOF \""
+                      << skel->getDof(dof)->getName() << "\"" << std::endl;
+            Eigen::MatrixXs compare = Eigen::MatrixXs::Zero(6, 3);
+            compare.col(0) = fd;
+            compare.col(1) = analytical;
+            compare.col(2) = analytical - fd;
+            std::cout << "FD - Analytical - Diff:" << std::endl
+                      << compare << std::endl;
+          }
+        }
+      }
+      return false;
+    }
+
+    Eigen::MatrixXs localAccJ = skel->getBodyLocalAccelerationsJacobian(wrt);
+    Eigen::MatrixXs localAccJ_fd
+        = skel->finiteDifferenceBodyLocalAccelerationsJacobian(wrt);
+    if (!equals(localAccJ, localAccJ_fd, 1e-8))
+    {
+      std::cout << "Acc wrt " << wrt->name() << " error!" << std::endl;
+      std::cout << "Analytical: " << std::endl << localAccJ << std::endl;
+      std::cout << "FD: " << std::endl << localAccJ_fd << std::endl;
+      std::cout << "Diff: " << std::endl
+                << localAccJ - localAccJ_fd << std::endl;
+      return false;
+    }
+
+    Eigen::MatrixXs gyroJ = skel->getGyroReadingsJacobianWrt(sensors, wrt);
+    Eigen::MatrixXs gyroJ_fd
+        = skel->finiteDifferenceGyroReadingsJacobianWrt(sensors, wrt);
+    if (!equals(gyroJ, gyroJ_fd, 1e-8))
+    {
+      std::cout << "Gyro wrt " << wrt->name() << " error!" << std::endl;
+      for (int i = 0; i < sensors.size(); i++)
+      {
+        for (int dof = 0; dof < gyroJ.cols(); dof++)
+        {
+          Eigen::Vector3s analytical = gyroJ.block<3, 1>(i * 3, dof);
+          Eigen::Vector3s fd = gyroJ_fd.block<3, 1>(i * 3, dof);
+          if (!equals(analytical, fd, 1e-8))
+          {
+            std::cout << "Sensor on body \"" << sensors[i].first->getName()
+                      << "\" @ [" << sensors[i].second.translation()(0) << ", "
+                      << sensors[i].second.translation()(1) << ", "
+                      << sensors[i].second.translation()(2)
+                      << "] disagrees WRT " << wrt->name() << "[" << i << "]"
+                      << std::endl;
+            Eigen::MatrixXs compare = Eigen::MatrixXs::Zero(3, 3);
+            compare.col(0) = fd;
+            compare.col(1) = analytical;
+            compare.col(2) = analytical - fd;
+            std::cout << "FD - Analytical - Diff:" << std::endl
+                      << compare << std::endl;
+          }
+        }
+      }
+      return false;
+    }
+
+    Eigen::MatrixXs accJ
+        = skel->getAccelerometerReadingsJacobianWrt(sensors, wrt);
+    Eigen::MatrixXs accJ_fd
+        = skel->finiteDifferenceAccelerometerReadingsJacobianWrt(sensors, wrt);
+    if (!equals(accJ, accJ_fd, 1e-8))
+    {
+      std::cout << "Accelerometer wrt " << wrt->name() << " error!"
+                << std::endl;
+      for (int i = 0; i < sensors.size(); i++)
+      {
+        for (int dof = 0; dof < accJ.cols(); dof++)
+        {
+          Eigen::Vector3s analytical = accJ.block<3, 1>(i * 3, dof);
+          Eigen::Vector3s fd = accJ_fd.block<3, 1>(i * 3, dof);
+          if (!equals(analytical, fd, 1e-8))
+          {
+            std::cout << "Sensor on body \"" << sensors[i].first->getName()
+                      << "\" @ [" << sensors[i].second.translation()(0) << ", "
+                      << sensors[i].second.translation()(1) << ", "
+                      << sensors[i].second.translation()(2)
+                      << "] disagrees WRT " << wrt->name() << "[" << i << "]"
+                      << std::endl;
+            Eigen::MatrixXs compare = Eigen::MatrixXs::Zero(3, 3);
+            compare.col(0) = fd;
+            compare.col(1) = analytical;
+            compare.col(2) = analytical - fd;
+            std::cout << "FD - Analytical - Diff:" << std::endl
+                      << compare << std::endl;
+          }
+        }
+      }
+      return false;
+    }
+  }
+  return true;
+}
+
+bool verifySpatialJacobians(std::shared_ptr<dynamics::Skeleton> skel)
+{
+  if (!verifyIMUJacobians(skel, neural::WithRespectTo::VELOCITY))
+  {
+    return false;
+  }
+  std::cout << "Passed VELOCITY" << std::endl;
+  if (!verifyIMUJacobians(skel, neural::WithRespectTo::GROUP_SCALES))
+  {
+    return false;
+  }
+  std::cout << "Passed GROUP_SCALES" << std::endl;
+  if (!verifyIMUJacobians(skel, neural::WithRespectTo::POSITION))
+  {
+    return false;
+  }
+  std::cout << "Passed POSITION" << std::endl;
+  if (!verifyIMUJacobians(skel, neural::WithRespectTo::ACCELERATION))
+  {
+    return false;
+  }
+  std::cout << "Passed ACCELERATION" << std::endl;
+  if (!verifyIMUJacobians(skel, neural::WithRespectTo::GROUP_COMS))
+  {
+    return false;
+  }
+  std::cout << "Passed GROUP_COMS" << std::endl;
+  return true;
+}
+
+#ifdef ALL_TESTS
+TEST(BODY_SPATIAL_TRANSLATION, BOX)
+{
+  std::shared_ptr<dynamics::Skeleton> skel = createBox(Eigen::Vector3s::Ones());
+  skel->getBodyNode(0)->setLocalCOM(Eigen::Vector3s::Random());
+  EXPECT_TRUE(verifySpatialJacobians(skel));
+}
+#endif
+
+#ifdef ALL_TESTS
+TEST(BODY_SPATIAL_TRANSLATION, BOX_WITH_CHILD_TRANSFORM)
+{
+  std::shared_ptr<dynamics::Skeleton> skel = createBox(Eigen::Vector3s::Ones());
+  Eigen::Isometry3s fromChild = Eigen::Isometry3s::Identity();
+  fromChild.translation() = Eigen::Vector3s::Random();
+  skel->getJoint(0)->setTransformFromChildBodyNode(fromChild);
+  skel->getBodyNode(0)->setLocalCOM(Eigen::Vector3s::Random());
+  EXPECT_TRUE(verifySpatialJacobians(skel));
+}
+#endif
+
+#ifdef ALL_TESTS
+TEST(BODY_SPATIAL_TRANSLATION, CARTPOLE)
+{
+  std::shared_ptr<dynamics::Skeleton> skel = createCartpole();
+  skel->getBodyNode(0)->setLocalCOM(Eigen::Vector3s::Random());
+  skel->getBodyNode(1)->setLocalCOM(Eigen::Vector3s::Random());
+  EXPECT_TRUE(verifySpatialJacobians(skel));
+}
+#endif
+
+#ifdef ALL_TESTS
+TEST(BODY_SPATIAL_TRANSLATION, TWO_LINK)
+{
+  std::shared_ptr<dynamics::Skeleton> skel = createTwoLinkRobot(
+      Eigen::Vector3s::Random().cwiseAbs(),
+      TypeOfDOF::DOF_ROLL,
+      Eigen::Vector3s::Random().cwiseAbs(),
+      TypeOfDOF::DOF_PITCH);
+  skel->getBodyNode(0)->setLocalCOM(Eigen::Vector3s::Random());
+  skel->getBodyNode(1)->setLocalCOM(Eigen::Vector3s::Random());
+  skel->getBodyNode(2)->setLocalCOM(Eigen::Vector3s::Random());
+  EXPECT_TRUE(verifySpatialJacobians(skel));
+}
+#endif
+
+#ifdef ALL_TESTS
+TEST(BODY_SPATIAL_TRANSLATION, THREE_LINK)
+{
+  std::shared_ptr<dynamics::Skeleton> skel = createThreeLinkRobot(
+      Eigen::Vector3s::Random().cwiseAbs(),
+      TypeOfDOF::DOF_ROLL,
+      Eigen::Vector3s::Random().cwiseAbs(),
+      TypeOfDOF::DOF_ROLL,
+      Eigen::Vector3s::Random().cwiseAbs(),
+      TypeOfDOF::DOF_PITCH);
+  skel->getBodyNode(0)->setLocalCOM(Eigen::Vector3s::Random());
+  skel->getBodyNode(1)->setLocalCOM(Eigen::Vector3s::Random());
+  skel->getBodyNode(2)->setLocalCOM(Eigen::Vector3s::Random());
+  EXPECT_TRUE(verifySpatialJacobians(skel));
+}
+#endif
+
+// #ifdef ALL_TESTS
+TEST(BODY_SPATIAL_TRANSLATION, EULER_FREE_JOINT)
+{
+  std::shared_ptr<dynamics::Skeleton> skel = dynamics::Skeleton::create();
+  auto eulerJointPair
+      = skel->createJointAndBodyNodePair<dynamics::EulerFreeJoint>();
+  dynamics::Joint* eulerJoint = eulerJointPair.first;
+  (void)eulerJoint;
+  dynamics::BodyNode* rootBody = eulerJointPair.second;
+  rootBody->setName("root");
+  rootBody->setLocalCOM(Eigen::Vector3s::Random());
+
+  auto revoluteJointPair
+      = rootBody->createChildJointAndBodyNodePair<dynamics::RevoluteJoint>();
+  dynamics::Joint* childJoint = revoluteJointPair.first;
+  dynamics::BodyNode* childBody = revoluteJointPair.second;
+  childBody->setName("child");
+  childBody->setLocalCOM(Eigen::Vector3s::Random());
+
+  Eigen::Isometry3s T_rc = Eigen::Isometry3s::Identity();
+  T_rc.translation() = Eigen::Vector3s::UnitX();
+  childJoint->setTransformFromParentBodyNode(T_rc.inverse());
+  childJoint->setTransformFromChildBodyNode(T_rc);
+
+  EXPECT_TRUE(verifySpatialJacobians(skel));
+}
+// #endif
+
+#ifdef ALL_TESTS
+TEST(BODY_SPATIAL_TRANSLATION, RAJAGOPAL)
+{
+  OpenSimFile file = OpenSimParser::parseOsim(
+      "dart://sample/osim/Rajagopal2015/Rajagopal2015.osim");
+  std::shared_ptr<dynamics::Skeleton> skel = file.skeleton;
+  skel->autogroupSymmetricSuffixes();
+
+  EXPECT_TRUE(verifySpatialJacobians(skel));
+}
+#endif


### PR DESCRIPTION
This adds support for computing virtual gyroscope and accelerometer readings at arbitrary points on a skeleton, and also computing Jacobians of those quantities with respect to anything in the `neural::WithRespectTo` enum.