### PR TITLE
Add option to turn off marker offsets optimization during dynamics initialization

### DIFF
--- a/dart/biomechanics/DynamicsFitter.cpp
+++ b/dart/biomechanics/DynamicsFitter.cpp
@@ -12134,7 +12134,8 @@ bool DynamicsFitter::timeSyncAndInitializePipeline(
     int maxBuckets,
     bool detectUnmeasuredTorque,
     s_t avgPositionChangeThreshold,
-    s_t avgAngularChangeThreshold)
+    s_t avgAngularChangeThreshold,
+    bool reoptimizeMarkerOffsets)
 {
   std::vector<Eigen::MatrixXs> originalPoseTrials;
   for (int i = 0; i < init->poseTrials.size(); i++)
@@ -12261,7 +12262,9 @@ bool DynamicsFitter::timeSyncAndInitializePipeline(
   }
 
   // Recompute the marker offsets to minimize error
-  optimizeMarkerOffsets(init);
+  if (reoptimizeMarkerOffsets) {
+    optimizeMarkerOffsets(init);
+  }
   return true;
 }
 

--- a/dart/biomechanics/DynamicsFitter.hpp
+++ b/dart/biomechanics/DynamicsFitter.hpp
@@ -1433,7 +1433,8 @@ public:
       int maxBuckets = 100,
       bool detectUnmeasuredTorque = true,
       s_t avgPositionChangeThreshold = 0.08,
-      s_t avgAngularChangeThreshold = 0.15);
+      s_t avgAngularChangeThreshold = 0.15,
+      bool reoptimizeMarkerOffsets = true);
 
   // 1.1. Attempt to shift the COM trajectory around to try to get the
   // residual-free trajectory. This can fail, when we've got unmeasured external

--- a/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
+++ b/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
@@ -626,7 +626,8 @@ protected:
           ::py::arg("maxBuckets") = 100,
           ::py::arg("detectUnmeasuredTorque") = true,
           ::py::arg("avgPositionChangeThreshold") = 0.08,
-          ::py::arg("avgAngularChangeThreshold") = 0.15)
+          ::py::arg("avgAngularChangeThreshold") = 0.15,
+          ::py::arg("reoptimizeMarkerOffsets") = true)
       .def(
           "optimizeSpatialResidualsOnCOMTrajectory",
           &dart::biomechanics::DynamicsFitter::


### PR DESCRIPTION
The call to `optimizeMarkerOffsets()` was messing up the marker offsets from `MarkerFitter`, so I added an option to turn it off in `timeSyncAndInitializePipeline`.  