### PR TITLE
Set zero velocity and acceleration bounds for locked coordinates

### DIFF
--- a/dart/biomechanics/OpenSimParser.cpp
+++ b/dart/biomechanics/OpenSimParser.cpp
@@ -4294,6 +4294,10 @@ std::pair<dynamics::Joint*, dynamics::BodyNode*> createJoint(
             coordinateCursor->FirstChildElement("default_value")->GetText());
         dof->setPositionLowerLimit(defaultValue);
         dof->setPositionUpperLimit(defaultValue);
+        dof->setVelocityLowerLimit(0);
+        dof->setVelocityUpperLimit(0);
+        dof->setAccelerationLowerLimit(0);
+        dof->setAccelerationUpperLimit(0);
         // This prevents warnings when copying the skeleton about out-of-bounds
         // rest positions
         dof->setRestPosition(defaultValue);


### PR DESCRIPTION
This PR sets zero bounds for the velocity and acceleration of locked coordinates to prevent small "wiggles" during dynamics fitting.
