### PR TITLE
Adding support for joint force field loss terms

### DIFF
--- a/dart/biomechanics/MarkerFitter.hpp
+++ b/dart/biomechanics/MarkerFitter.hpp
@@ -788,6 +788,17 @@ public:
   /// compared to other terms.
   void setStaticTrialWeight(s_t weight);
 
+  /// This sets the minimum distance joints have to be apart in order to get
+  /// zero "force field" loss. Any joints closer than this (in world space) will
+  /// incur a penalty.
+  void setJointForceFieldThresholdDistance(s_t minDistance);
+
+  /// Larger values will increase the softness of the threshold penalty. Smaller
+  /// values, as they approach zero, will have an almost perfectly vertical
+  /// penality for going below the threshold distance. That would be hard to
+  /// optimize, so don't make it too small.
+  void setJointForceFieldSoftness(s_t softness);
+
   /// Sets the loss and gradient function
   void setCustomLossAndGrad(
       std::function<s_t(MarkerFitterState*)> customLossAndGrad);
@@ -1021,6 +1032,8 @@ protected:
   s_t mAnatomicalMarkerDefaultWeight;
   s_t mTrackingMarkerDefaultWeight;
   s_t mStaticTrialWeight;
+  s_t mJointForceFieldThresholdDistance;
+  s_t mJointForceFieldSoftness;
 
   // These are IPOPT settings
   double mTolerance;

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -1363,6 +1363,84 @@ public:
   Eigen::MatrixXs finiteDifferenceJointWorldPositionsJacobianWrtBodyScales(
       const std::vector<dynamics::Joint*>& joints);
 
+  /// This returns a score for a force field, which runs a simple non-linear
+  /// function over the joint distance
+  s_t getJointForceFieldToOtherJoints(
+      const std::vector<dynamics::Joint*>& joints,
+      int jointIndex,
+      s_t barrierDistance,
+      s_t softness);
+
+  /// This returns a score for a force field, which runs a simple non-linear
+  /// function over the joint distance
+  Eigen::VectorXs getJointForceFieldToOtherJointsGradient(
+      const std::vector<dynamics::Joint*>& joints,
+      int jointIndex,
+      s_t barrierDistance,
+      s_t softness,
+      neural::WithRespectTo* wrt);
+
+  /// This returns a score for a force field, which runs a simple non-linear
+  /// function over the joint distance
+  Eigen::VectorXs finiteDifferenceJointForceFieldToOtherJointsGradient(
+      const std::vector<dynamics::Joint*>& joints,
+      int jointIndex,
+      s_t barrierDistance,
+      s_t softness,
+      neural::WithRespectTo* wrt);
+
+  /// This returns a score for a force field, which runs a simple non-linear
+  /// function over the joint distance with respect to body scales, which for
+  /// historical reasons is not supported in the neural::WithRespectTo API.
+  /// TODO: correct that
+  Eigen::VectorXs getJointForceFieldToOtherJointsGradientWrtBodyScales(
+      const std::vector<dynamics::Joint*>& joints,
+      int jointIndex,
+      s_t barrierDistance,
+      s_t softness);
+
+  /// This returns a score for a force field, which runs a simple non-linear
+  /// function over the joint distance with respect to body scales, which for
+  /// historical reasons is not supported in the neural::WithRespectTo API.
+  /// TODO: correct that
+  Eigen::VectorXs
+  finiteDifferenceJointForceFieldToOtherJointsGradientWrtBodyScales(
+      const std::vector<dynamics::Joint*>& joints,
+      int jointIndex,
+      s_t barrierDistance,
+      s_t softness);
+
+  /// This returns a vector of the distance to all joints after the joint
+  Eigen::VectorXs getJointDistanceToOtherJoints(
+      const std::vector<dynamics::Joint*>& joints, int jointIndex);
+
+  /// This returns a Jacobian of the distance to every joint in the body with
+  /// respect to WRT
+  Eigen::MatrixXs getJointDistanceToOtherJointsJacobianWrt(
+      const std::vector<dynamics::Joint*>& joints,
+      int jointIndex,
+      neural::WithRespectTo* wrt);
+
+  /// This returns a Jacobian of the distance to every joint in the body with
+  /// respect to WRT
+  Eigen::MatrixXs finiteDifferenceJointDistanceToOtherJointsJacobianWrt(
+      const std::vector<dynamics::Joint*>& joints,
+      int jointIndex,
+      neural::WithRespectTo* wrt);
+
+  /// This returns a Jacobian of the distance to every joint in the body with
+  /// respect to body scales, which for historical reasons is not supported in
+  /// the neural::WithRespectTo API. TODO: correct that
+  Eigen::MatrixXs getJointDistanceToOtherJointsJacobianWrtBodyScales(
+      const std::vector<dynamics::Joint*>& joints, int jointIndex);
+
+  /// This returns a Jacobian of the distance to every joint in the body with
+  /// respect to body scales, which for historical reasons is not supported in
+  /// the neural::WithRespectTo API. TODO: correct that
+  Eigen::MatrixXs
+  finiteDifferenceJointDistanceToOtherJointsJacobianWrtBodyScales(
+      const std::vector<dynamics::Joint*>& joints, int jointIndex);
+
   /// These are a set of bodies, and offsets in local body space where markers
   /// are mounted on the body
   std::map<std::string, Eigen::Vector3s> getMarkerMapWorldPositions(

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -1414,6 +1414,21 @@ public:
   Eigen::VectorXs getJointDistanceToOtherJoints(
       const std::vector<dynamics::Joint*>& joints, int jointIndex);
 
+  /// This gets the Jacobian relating changes in the joint world positions
+  /// (IMPORTANT: NOT JOINT ANGLE - physical position of joint centers in the
+  /// world) to the changes in the joint distance measurement vector for joint
+  /// `jointIndex`.
+  Eigen::MatrixXs getJointDistanceToOtherJointsJacobianWrtJointWorldPositions(
+      const std::vector<dynamics::Joint*>& joints, int jointIndex);
+
+  /// This gets the Jacobian relating changes in the joint world positions
+  /// (IMPORTANT: NOT JOINT ANGLE - physical position of joint centers in the
+  /// world) to the changes in the joint distance measurement vector for joint
+  /// `jointIndex`.
+  Eigen::MatrixXs
+  finiteDifferenceJointDistanceToOtherJointsJacobianWrtJointWorldPositions(
+      const std::vector<dynamics::Joint*>& joints, int jointIndex);
+
   /// This returns a Jacobian of the distance to every joint in the body with
   /// respect to WRT
   Eigen::MatrixXs getJointDistanceToOtherJointsJacobianWrt(

--- a/dart/math/Geometry.cpp
+++ b/dart/math/Geometry.cpp
@@ -771,12 +771,12 @@ Eigen::Vector3s dLogMap(const Eigen::Matrix3s& _R, const Eigen::Matrix3s& dR)
   s_t diagSum = 0.5 * (_R(0, 0) + _R(1, 1) + _R(2, 2) - 1.0);
   s_t d_diagSum = 0.5 * (dR(0, 0) + dR(1, 1) + dR(2, 2));
   s_t d_theta = 0.0;
-  if (diagSum > 1.0)
+  if (diagSum >= 1.0)
   {
     diagSum = 1.0;
     d_theta = 0.0;
   }
-  else if (diagSum < -1.0)
+  else if (diagSum <= -1.0)
   {
     diagSum = -1.0;
     d_theta = 0.0;

--- a/dart/neural/WithRespectTo.cpp
+++ b/dart/neural/WithRespectTo.cpp
@@ -239,7 +239,7 @@ Eigen::VectorXs WithRespectToGroupScales::get(dynamics::Skeleton* skel)
 void WithRespectToGroupScales::set(
     simulation::World* world, Eigen::VectorXs value)
 {
-  world->setAccelerations(value);
+  world->setGroupScales(value);
 }
 
 /// This sets the world's state based on our WRT

--- a/python/_nimblephysics/biomechanics/MarkerFitter.cpp
+++ b/python/_nimblephysics/biomechanics/MarkerFitter.cpp
@@ -272,6 +272,26 @@ void MarkerFitter(py::module& m)
           &dart::biomechanics::MarkerFitter::setStaticTrialWeight,
           ::py::arg("weight"))
       .def(
+          "setJointForceFieldThresholdDistance",
+          &dart::biomechanics::MarkerFitter::
+              setJointForceFieldThresholdDistance,
+          ::py::arg("minDistance"),
+          R"pydoc(
+  This sets the minimum distance joints have to be apart in order to get
+  zero "force field" loss. Any joints closer than this (in world space) will
+  incur a penalty.
+          )pydoc")
+      .def(
+          "setJointForceFieldSoftness",
+          &dart::biomechanics::MarkerFitter::setJointForceFieldSoftness,
+          ::py::arg("softness"),
+          R"pydoc(
+  Larger values will increase the softness of the threshold penalty. Smaller
+  values, as they approach zero, will have an almost perfectly vertical
+  penality for going below the threshold distance. That would be hard to
+  optimize, so don't make it too small.
+          )pydoc")
+      .def(
           "setCustomLossAndGrad",
           &dart::biomechanics::MarkerFitter::setCustomLossAndGrad,
           ::py::arg("loss"))

--- a/unittests/unit/CMakeLists.txt
+++ b/unittests/unit/CMakeLists.txt
@@ -199,6 +199,10 @@ if(TARGET dart-utils-urdf)
   dart_add_test("unit" test_CompleteHumanModel)
   target_link_libraries(test_CompleteHumanModel dart-utils)
   target_link_libraries(test_CompleteHumanModel dart-utils-urdf)
+
+  dart_add_test("unit" test_JointForceField)
+  target_link_libraries(test_JointForceField dart-utils)
+  target_link_libraries(test_JointForceField dart-utils-urdf)
 endif()
 
 if(TARGET dart-planning)

--- a/unittests/unit/test_JointForceField.cpp
+++ b/unittests/unit/test_JointForceField.cpp
@@ -1,0 +1,124 @@
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "dart/biomechanics/OpenSimParser.hpp"
+#include "dart/biomechanics/SkeletonConverter.hpp"
+#include "dart/dynamics/BallJoint.hpp"
+#include "dart/dynamics/FreeJoint.hpp"
+#include "dart/dynamics/Joint.hpp"
+#include "dart/dynamics/Skeleton.hpp"
+#include "dart/math/Geometry.hpp"
+#include "dart/math/MathTypes.hpp"
+#include "dart/neural/WithRespectTo.hpp"
+#include "dart/realtime/Ticker.hpp"
+#include "dart/server/GUIWebsocketServer.hpp"
+#include "dart/utils/DartResourceRetriever.hpp"
+
+#include "GradientTestUtils.hpp"
+#include "TestHelpers.hpp"
+
+#define ALL_TESTS
+
+using namespace dart;
+using namespace biomechanics;
+using namespace server;
+using namespace realtime;
+
+#ifdef ALL_TESTS
+TEST(JointForceFields, FORCE_FIELD_JACS_GRAD)
+{
+  std::shared_ptr<dynamics::Skeleton> osim
+      = OpenSimParser::parseOsim(
+            "dart://sample/osim/Rajagopal2015/Rajagopal2015.osim")
+            .skeleton;
+
+  std::vector<dynamics::Joint*> joints;
+  for (int i = 0; i < osim->getNumJoints(); i++)
+  {
+    joints.push_back(osim->getJoint(i));
+  }
+
+  std::vector<neural::WithRespectTo*> wrts;
+  wrts.push_back(neural::WithRespectTo::POSITION);
+  wrts.push_back(neural::WithRespectTo::VELOCITY);
+  wrts.push_back(neural::WithRespectTo::ACCELERATION);
+  wrts.push_back(neural::WithRespectTo::GROUP_SCALES);
+  wrts.push_back(neural::WithRespectTo::GROUP_COMS);
+
+  for (int i = 0; i < joints.size(); i++)
+  {
+    std::cout << "  Testing Joint " << i << "/" << joints.size() << std::endl;
+    for (neural::WithRespectTo* wrt : wrts)
+    {
+      std::cout << "Testing WRT " << wrt->name() << std::endl;
+      Eigen::MatrixXs analyticalJac
+          = osim->getJointDistanceToOtherJointsJacobianWrt(joints, i, wrt);
+      Eigen::MatrixXs bruteForceJac
+          = osim->finiteDifferenceJointDistanceToOtherJointsJacobianWrt(
+              joints, i, wrt);
+      if (!equals(analyticalJac, bruteForceJac, 1e-8))
+      {
+        std::cout << "Joint distance jacobian wrt " << wrt->name()
+                  << " disagrees!" << std::endl;
+        std::cout << "Analytical: " << std::endl << analyticalJac << std::endl;
+        std::cout << "Brute force: " << std::endl << bruteForceJac << std::endl;
+        std::cout << "Diff: " << std::endl
+                  << analyticalJac - bruteForceJac << std::endl;
+        EXPECT_TRUE(equals(analyticalJac, bruteForceJac, 1e-8));
+      }
+
+      Eigen::MatrixXs analyticalGrad
+          = osim->getJointForceFieldToOtherJointsGradient(
+              joints, i, 10.0, 0.2, wrt);
+      Eigen::MatrixXs bruteForceGrad
+          = osim->finiteDifferenceJointForceFieldToOtherJointsGradient(
+              joints, i, 10.0, 0.2, wrt);
+      if (!equals(analyticalGrad, bruteForceGrad, 1e-8))
+      {
+        std::cout << "Joint force field grad wrt " << wrt->name()
+                  << " disagrees!" << std::endl;
+        std::cout << "Analytical: " << std::endl << analyticalGrad << std::endl;
+        std::cout << "Brute force: " << std::endl
+                  << bruteForceGrad << std::endl;
+        std::cout << "Diff: " << std::endl
+                  << analyticalGrad - bruteForceGrad << std::endl;
+        EXPECT_TRUE(equals(analyticalGrad, bruteForceGrad, 1e-8));
+      }
+    }
+    std::cout << "Testing WRT body scales" << std::endl;
+    Eigen::MatrixXs analyticalJac
+        = osim->getJointDistanceToOtherJointsJacobianWrtBodyScales(joints, i);
+    Eigen::MatrixXs bruteForceJac
+        = osim->finiteDifferenceJointDistanceToOtherJointsJacobianWrtBodyScales(
+            joints, i);
+    if (!equals(analyticalJac, bruteForceJac, 1e-8))
+    {
+      std::cout << "Joint distance jacobian wrt body scales disagrees!"
+                << std::endl;
+      std::cout << "Analytical: " << std::endl << analyticalJac << std::endl;
+      std::cout << "Brute force: " << std::endl << bruteForceJac << std::endl;
+      std::cout << "Diff: " << std::endl
+                << analyticalJac - bruteForceJac << std::endl;
+      EXPECT_TRUE(equals(analyticalJac, bruteForceJac, 1e-8));
+    }
+
+    Eigen::MatrixXs analyticalGrad
+        = osim->getJointForceFieldToOtherJointsGradientWrtBodyScales(
+            joints, i, 10.0, 0.2);
+    Eigen::MatrixXs bruteForceGrad
+        = osim->finiteDifferenceJointForceFieldToOtherJointsGradientWrtBodyScales(
+            joints, i, 10.0, 0.2);
+    if (!equals(analyticalGrad, bruteForceGrad, 1e-8))
+    {
+      std::cout << "Joint force field grad wrt body scales disagrees!"
+                << std::endl;
+      std::cout << "Analytical: " << std::endl << analyticalGrad << std::endl;
+      std::cout << "Brute force: " << std::endl << bruteForceGrad << std::endl;
+      std::cout << "Diff: " << std::endl
+                << analyticalGrad - bruteForceGrad << std::endl;
+      EXPECT_TRUE(equals(analyticalGrad, bruteForceGrad, 1e-8));
+    }
+  }
+}
+#endif

--- a/unittests/unit/test_MarkerFitter.cpp
+++ b/unittests/unit/test_MarkerFitter.cpp
@@ -1462,6 +1462,8 @@ std::vector<MarkerInitialization> runEngine(
   // Default max joint weight is 0.5, so this is 2x the default value
   fitter.setMaxJointWeight(1.0);
 
+  fitter.setStaticTrialWeight(0.1);
+
   // fitter.setDebugLoss(true);
 
   // Create Anthropometric prior
@@ -2487,6 +2489,7 @@ TEST(MarkerFitter, DERIVATIVES)
 
   MarkerFitter fitter(osim, markers);
   fitter.setInitialIKSatisfactoryLoss(0.05);
+  fitter.setStaticTrialWeight(0.1);
   fitter.setInitialIKMaxRestarts(2);
   fitter.addZeroConstraint("trivial", [&](MarkerFitterState* state) {
     (void)state;
@@ -2571,6 +2574,7 @@ TEST(MarkerFitter, DERIVATIVES_BALL_JOINTS)
   MarkerFitter fitter(osimBallJoints, markers);
   fitter.setInitialIKSatisfactoryLoss(0.05);
   fitter.setInitialIKMaxRestarts(2);
+  fitter.setStaticTrialWeight(0.1);
   fitter.addZeroConstraint("trivial", [&](MarkerFitterState* state) {
     (void)state;
     return 0.0;
@@ -2640,6 +2644,7 @@ TEST(MarkerFitter, DERIVATIVES_COMPLETE_HUMAN)
   MarkerFitter fitter(osim, markers);
   fitter.setInitialIKSatisfactoryLoss(0.05);
   fitter.setInitialIKMaxRestarts(2);
+  fitter.setStaticTrialWeight(0.1);
   fitter.addZeroConstraint("trivial", [&](MarkerFitterState* state) {
     (void)state;
     return 0.0;
@@ -2733,6 +2738,7 @@ TEST(MarkerFitter, DERIVATIVES_ARNOLD)
   MarkerFitter fitter(osim, markers);
   fitter.setInitialIKSatisfactoryLoss(0.05);
   fitter.setInitialIKMaxRestarts(2);
+  fitter.setStaticTrialWeight(0.1);
   fitter.addZeroConstraint("trivial", [&](MarkerFitterState* state) {
     (void)state;
     return 0.0;
@@ -2808,6 +2814,9 @@ TEST(MarkerFitter, DERIVATIVES_ARNOLD_BALL_JOINTS)
   MarkerFitter fitter(osimBallJoints, markers);
   fitter.setInitialIKSatisfactoryLoss(0.05);
   fitter.setInitialIKMaxRestarts(2);
+  fitter.setStaticTrialWeight(0.01);
+  fitter.setJointForceFieldThresholdDistance(0);
+  fitter.setJointForceFieldSoftness(100.0);
   fitter.addZeroConstraint("trivial", [&](MarkerFitterState* state) {
     (void)state;
     return 0.0;


### PR DESCRIPTION
Got a prototype of a loss term that can penalize joints getting too close together in the MarkerFitter bilevel optimization problem.