### PR TITLE
AccelerationSmeethor will not change locked DOFs

### DIFF
--- a/dart/biomechanics/DynamicsFitter.cpp
+++ b/dart/biomechanics/DynamicsFitter.cpp
@@ -10034,7 +10034,7 @@ void DynamicsFitter::smoothAccelerations(
 
     init->poseTrials[trial] = smoother.smooth(init->poseTrials[trial]);
 
-    // #ifndef NDEBUG
+    #ifndef NDEBUG
     // Warn if we're over a bound after acceleration smoothing
     s_t eps = 1e-6;
     for (int t = 0; t < init->poseTrials[trial].cols(); t++)
@@ -10058,7 +10058,7 @@ void DynamicsFitter::smoothAccelerations(
         }
       }
     }
-    // #endif
+    #endif
 
     // Smooth the regularization target, too, so we're not regularizing
     // our positions back to something jittery later

--- a/dart/utils/AccelerationSmoother.cpp
+++ b/dart/utils/AccelerationSmoother.cpp
@@ -101,6 +101,11 @@ Eigen::MatrixXs AccelerationSmoother::smooth(Eigen::MatrixXs series)
 
   for (int row = 0; row < series.rows(); row++)
   {
+    // If all the values in this row are identical, it's probably a locked joint, and we can't smooth it.
+    if (series.row(row).maxCoeff() == series.row(row).minCoeff()) {
+      smoothed.row(row) = series.row(row);
+      continue;
+    }
     Eigen::VectorXs c = Eigen::VectorXs::Zero(mSmoothedTimesteps + mTimesteps);
     c.segment(mSmoothedTimesteps, mTimesteps)
         = mRegularizationWeight * series.row(row);

--- a/unittests/unit/test_AccelerationSmoother.cpp
+++ b/unittests/unit/test_AccelerationSmoother.cpp
@@ -86,3 +86,19 @@ TEST(ACCEL_SMOOTHER, HUGE_TRAJECTORY)
             << std::endl;
 }
 #endif
+
+#ifdef ALL_TESTS
+TEST(ACCEL_SMOOTHER, LOCKED_ROW)
+{
+  int dofs = 2;
+  int timesteps = 300;
+  Eigen::MatrixXs data = Eigen::MatrixXs::Random(dofs, timesteps);
+  // Set row 1 to a constant 0.0
+  data.row(1).setConstant(0.0);
+
+  AccelerationSmoother smootherIterative(timesteps, 1, 0.05, true, true);
+  Eigen::MatrixXs smoothedIterative = smootherIterative.smooth(data);
+
+  EXPECT_TRUE(smoothedIterative.row(1).isConstant(0.0));
+}
+#endif


### PR DESCRIPTION
and DynamicsFitter won't spam the logs with warnings about locked DOFs.