### PR TITLE
Correctly smooth final poses in `MarkerFitter` after final IK step

### DIFF
--- a/dart/biomechanics/MarkerFitter.cpp
+++ b/dart/biomechanics/MarkerFitter.cpp
@@ -3088,11 +3088,6 @@ MarkerInitialization MarkerFitter::completeBilevelResult(
   // 7. Do one final "polishing pass" on all the IK
   std::cout << "Done completing bilevel fit!" << std::endl;
 
-  std::cout << "Running final smoothing IK" << std::endl;
-  std::cout << "  " << result.poses.cols() << " poses" << std::endl;
-  std::cout << "  " << result.joints.size() << " joints" << std::endl;
-  std::cout << "  " << markerObservations.size() << " marker observations"
-            << std::endl;
   return smoothOutIK(markerObservations, newClip, result);
 
   // return result;

--- a/dart/biomechanics/MarkerFitter.cpp
+++ b/dart/biomechanics/MarkerFitter.cpp
@@ -3088,6 +3088,7 @@ MarkerInitialization MarkerFitter::completeBilevelResult(
   // 7. Do one final "polishing pass" on all the IK
   std::cout << "Done completing bilevel fit!" << std::endl;
 
+  std::cout << "Running final smoothing IK" << std::endl;
   return smoothOutIK(markerObservations, newClip, result);
 
   // return result;

--- a/dart/biomechanics/MarkerFitter.cpp
+++ b/dart/biomechanics/MarkerFitter.cpp
@@ -3089,6 +3089,10 @@ MarkerInitialization MarkerFitter::completeBilevelResult(
   std::cout << "Done completing bilevel fit!" << std::endl;
 
   std::cout << "Running final smoothing IK" << std::endl;
+  std::cout << "  " << result.poses.cols() << " poses" << std::endl;
+  std::cout << "  " << result.joints.size() << " joints" << std::endl;
+  std::cout << "  " << markerObservations.size() << " marker observations"
+            << std::endl;
   return smoothOutIK(markerObservations, newClip, result);
 
   // return result;
@@ -3410,10 +3414,10 @@ MarkerInitialization MarkerFitter::smoothOutIK(
     std::cout << "Smoothing trial poses for trial " << i << "/"
               << trialStarts.size() << std::endl;
     int start = trialStarts[i];
-    int size = trialStarts[i];
     AccelerationSmoother smoother(size, 1.0, 0.001);
     smoother.smooth(
-        smoothed.poses.block(0, start, smoothed.poses.rows(), size));
+        smoothed.poses.block(0, start, smoothed.poses.rows(),
+                                       smoothed.poses.cols()));
   }
 
   return smoothed;

--- a/dart/biomechanics/MarkerFitter.cpp
+++ b/dart/biomechanics/MarkerFitter.cpp
@@ -3410,10 +3410,10 @@ MarkerInitialization MarkerFitter::smoothOutIK(
     std::cout << "Smoothing trial poses for trial " << i << "/"
               << trialStarts.size() << std::endl;
     int start = trialStarts[i];
+    int size = trialSizes[i];
     AccelerationSmoother smoother(size, 1.0, 0.001);
     smoother.smooth(
-        smoothed.poses.block(0, start, smoothed.poses.rows(),
-                                       smoothed.poses.cols()));
+        smoothed.poses.block(0, start, smoothed.poses.rows(), size));
   }
 
   return smoothed;


### PR DESCRIPTION
When smoothing the individual trials after the final IK in `MarkerFitter`, the wrong block matrix of the trial poses when being passed to `AccelerationSmoother`. In the case of the first trial, `size` ended up being zero, which triggered a seg fault after the recent changes to `AccelerationSmoother` tried to access a non-existent row in the input data.
