### PR TITLE
Prefer axis fits to sphere fits, if both are below an absolute value

### DIFF
--- a/dart/biomechanics/MarkerFitter.hpp
+++ b/dart/biomechanics/MarkerFitter.hpp
@@ -769,9 +769,13 @@ public:
   /// Sets the maximum number of iterations for IPOPT
   void setIterationLimit(int limit);
 
-  /// Sets the number of SGD iterations to run when fitting joint center / axis
+  /// Sets the number of SGD iterations to run when fitting joint center
   /// problems
-  void setJointFitSGDIterations(int iters);
+  void setJointSphereFitSGDIterations(int iters);
+
+  /// Sets the number of SGD iterations to run when fitting joint axis
+  /// problems
+  void setJointAxisFitSGDIterations(int iters);
 
   /// This sets an anthropometric prior which is used by the default loss. If
   /// you've called `setCustomLossAndGrad` then this has no effect.
@@ -1044,7 +1048,8 @@ protected:
   bool mSilenceOutput;
   bool mDisableLinesearch;
 
-  int mJointFitSGDIterations;
+  int mJointSphereFitSGDIterations;
+  int mJointAxisFitSGDIterations;
 };
 
 /*

--- a/python/_nimblephysics/biomechanics/MarkerFitter.cpp
+++ b/python/_nimblephysics/biomechanics/MarkerFitter.cpp
@@ -411,6 +411,14 @@ void MarkerFitter(py::module& m)
           &dart::biomechanics::MarkerFitter::setTrackingMarkerDefaultWeight,
           ::py::arg("weight"))
       .def(
+          "setJointSphereFitSGDIterations",
+          &dart::biomechanics::MarkerFitter::setJointSphereFitSGDIterations,
+          ::py::arg("iters"))
+      .def(
+          "setJointAxisFitSGDIterations",
+          &dart::biomechanics::MarkerFitter::setJointAxisFitSGDIterations,
+          ::py::arg("iters"))
+      .def(
           "debugTrajectoryAndMarkersToGUI",
           &dart::biomechanics::MarkerFitter::debugTrajectoryAndMarkersToGUI,
           ::py::arg("server"),

--- a/unittests/unit/test_DynamicsFitter.cpp
+++ b/unittests/unit/test_DynamicsFitter.cpp
@@ -3350,7 +3350,7 @@ std::shared_ptr<DynamicsInitialization> createInitialization(
     }
 
     // 2. Find the joint centers
-    fitter.setJointFitSGDIterations(50); // TODO comment out in Release build
+    // fitter.setJointSphereFitSGDIterations(50); // TODO comment out in Release build
     fitter.findJointCenters(
         fitterInit, newClip, markerObservationTrials[trial]);
     fitter.findAllJointAxis(
@@ -3543,6 +3543,10 @@ std::pair<std::vector<MarkerInitialization>, OpenSimFile> runMarkerFitter(
   fitter.setMinAxisFitScore(0.001);
   // Default max joint weight is 0.5, so this is 2x the default value
   fitter.setMaxJointWeight(1.0);
+
+  // Try with a joint force field at 10cm
+  // fitter.setJointForceFieldThresholdDistance(0.1);
+  // fitter.setJointForceFieldSoftness(10.0);
 
   // Create Anthropometric prior
   std::shared_ptr<Anthropometrics> anthropometrics


### PR DESCRIPTION
We were using a heuristic to choose between axis fits and sphere fits that we'd choose the axis fit if its loss was below 5x the sphere fit loss (because axis fits are a harder problem). Where this got us into trouble was if both losses were very small, it's easy to have loss be more than 5x a sphere fit loss that's like 1e-5, while still being a perfectly acceptable value of 0.001 or something. So now we have an absolute threshold.