### PR TITLE
Fixing Antoine's shivering calibration example

### DIFF
--- a/dart/biomechanics/MarkerFixer.cpp
+++ b/dart/biomechanics/MarkerFixer.cpp
@@ -801,7 +801,8 @@ void RippleReductionProblem::saveToGUI(std::string markerName, std::string path)
 std::shared_ptr<MarkersErrorReport> MarkerFixer::generateDataErrorsReport(
     const std::vector<std::map<std::string, Eigen::Vector3s>>&
         immutableMarkerObservations,
-    s_t dt)
+    s_t dt,
+    bool dropProlongedStillness)
 {
   std::shared_ptr<MarkersErrorReport> report
       = std::make_shared<MarkersErrorReport>();
@@ -829,7 +830,10 @@ std::shared_ptr<MarkersErrorReport> MarkerFixer::generateDataErrorsReport(
     }
     std::string bestLabel = traces[i].getBestLabel(alreadyTakenLabels);
     traces[i].filterTimestepsBasedOnAcc(dt, 1000.0);
-    // traces[i].filterTimestepsBasedOnProlongedStillness(dt, 0.001, 10);
+    if (dropProlongedStillness)
+    {
+      traces[i].filterTimestepsBasedOnProlongedStillness(dt, 0.001, 10);
+    }
     traceLabels.push_back(bestLabel);
   }
 

--- a/dart/biomechanics/MarkerFixer.cpp
+++ b/dart/biomechanics/MarkerFixer.cpp
@@ -557,8 +557,8 @@ int RippleReductionProblem::dropSuspiciousPoints(MarkersErrorReport* report)
         if (report != nullptr)
         {
           report->warnings.push_back(
-              "Dropping marker " + markerName
-              + " for suspicious acceleration (" + std::to_string(acc.norm()) + "m/s^2) on frame "
+              "Dropping marker " + markerName + " for suspicious acceleration ("
+              + std::to_string(acc.norm()) + "m/s^2) on frame "
               + std::to_string(observedTimesteps[i]));
         }
         dropped++;
@@ -810,9 +810,10 @@ std::shared_ptr<MarkersErrorReport> MarkerFixer::generateDataErrorsReport(
 
   // 1. Attempt to detect marker flips that occur partway through the trajectory
 
-  // 1.1. Collect markers into continuous traces. Break marker traces that imply a velocity greater than 20 m/s
-  std::vector<LabeledMarkerTrace> traces
-      = LabeledMarkerTrace::createRawTraces(immutableMarkerObservations, dt * 20.0);
+  // 1.1. Collect markers into continuous traces. Break marker traces that imply
+  // a velocity greater than 20 m/s
+  std::vector<LabeledMarkerTrace> traces = LabeledMarkerTrace::createRawTraces(
+      immutableMarkerObservations, dt * 20.0);
 
   // 1.2. Label the traces based on their majority label during the trace
   std::vector<std::string> traceLabels;
@@ -828,7 +829,7 @@ std::shared_ptr<MarkersErrorReport> MarkerFixer::generateDataErrorsReport(
     }
     std::string bestLabel = traces[i].getBestLabel(alreadyTakenLabels);
     traces[i].filterTimestepsBasedOnAcc(dt, 1000.0);
-    traces[i].filterTimestepsBasedOnProlongedStillness(dt, 0.001, 10);
+    // traces[i].filterTimestepsBasedOnProlongedStillness(dt, 0.001, 10);
     traceLabels.push_back(bestLabel);
   }
 

--- a/dart/biomechanics/MarkerFixer.hpp
+++ b/dart/biomechanics/MarkerFixer.hpp
@@ -151,7 +151,8 @@ public:
   static std::shared_ptr<MarkersErrorReport> generateDataErrorsReport(
       const std::vector<std::map<std::string, Eigen::Vector3s>>&
           markerObservations,
-      s_t dt);
+      s_t dt,
+      bool dropProlongedStillness = false);
 };
 
 } // namespace biomechanics

--- a/python/_nimblephysics/biomechanics/MarkerFixer.cpp
+++ b/python/_nimblephysics/biomechanics/MarkerFixer.cpp
@@ -63,7 +63,8 @@ void MarkerFixer(py::module& m)
           "generateDataErrorsReport",
           &dart::biomechanics::MarkerFixer::generateDataErrorsReport,
           ::py::arg("immutableMarkerObservations"),
-          ::py::arg("dt"));
+          ::py::arg("dt"),
+          ::py::arg("dropProlongedStillness") = false);
 }
 
 } // namespace python

--- a/unittests/unit/test_MarkerFitter.cpp
+++ b/unittests/unit/test_MarkerFitter.cpp
@@ -6271,6 +6271,36 @@ TEST(MarkerFitter, COMPLETE_HUMAN_MODEL_BALLET)
 #endif
 
 #ifdef ALL_TESTS
+TEST(MarkerFitter, ANTOINE_BUG_1)
+{
+  std::vector<std::string> c3dFiles;
+  std::vector<std::string> trcFiles;
+  std::vector<std::string> grfFiles;
+
+  trcFiles.push_back(
+      "dart://sample/osim/Antoine_Subj03_input/trials/Mocap0001/markers.trc");
+  trcFiles.push_back(
+      "dart://sample/osim/Antoine_Subj03_input/trials/Mocap0002/markers.trc");
+  trcFiles.push_back(
+      "dart://sample/osim/Antoine_Subj03_input/trials/Mocap0003/markers.trc");
+  trcFiles.push_back(
+      "dart://sample/osim/Antoine_Subj03_input/trials/Mocap0004/markers.trc");
+
+  //  {"massKg": 79.1, "heightM": 1.8, "sex": "male", "skeletonPreset":
+  //  "custom"}
+  runEngine(
+      "dart://sample/osim/Antoine_Subj03_input/unscaled_generic.osim",
+      c3dFiles,
+      trcFiles,
+      grfFiles,
+      79.1,
+      1.8,
+      "male",
+      true);
+}
+#endif
+
+#ifdef ALL_TESTS
 TEST(MarkerFitter, MULTI_TRIAL_MICHAEL)
 {
   bool isDebug = false;


### PR DESCRIPTION
The problem here was that we were dropping markers that don't move for a prolonged period of time, on the basis that they've probably fallen off the body or been incorrectly gap-filled. Antoine's example had tens of thousands of frames of markers not moving at all, which meant those markers were getting dropped and so IK was not constrained by anything, so it got some wonky solutions. By just removing that filter we've fixed his issue.