### PR TITLE
Automatically switch to using reaction wheels if too many external torques are detected

### DIFF
--- a/dart/biomechanics/MarkerFitter.cpp
+++ b/dart/biomechanics/MarkerFitter.cpp
@@ -4603,9 +4603,9 @@ ScaleAndFitResult MarkerFitter::scaleAndFit(
     }
 
     // The extra dimension is for the anthropometric penalty term
-    int outputDim
-        = (markerObservations.size() * 3) + (joints.size() * 3);
-    if (fitter->mAnthropometrics != nullptr) {
+    int outputDim = (markerObservations.size() * 3) + (joints.size() * 3);
+    if (fitter->mAnthropometrics != nullptr)
+    {
       outputDim += 1;
     }
 
@@ -4863,13 +4863,14 @@ ScaleAndFitResult MarkerFitter::scaleAndFit(
               axisWeights);
 
           // Add group scales grad
-          if (fitter->mAnthropometrics != nullptr) {
+          if (fitter->mAnthropometrics != nullptr)
+          {
             Eigen::VectorXs expNegLogPdfGradient
                 = -alphaScale * expNegLogPdf
                   * fitter->mAnthropometrics->getGradientOfLogPDFWrtGroupScales(
                       skeletonBallJoints);
             int groupScaleDim = skeletonBallJoints->getGroupScaleDim();
-            assert(groupScaleDim == expLogPdfGradient.size());
+            assert(groupScaleDim == expNegLogPdfGradient.size());
             assert(
                 jac.cols() == skeletonBallJoints->getNumDofs() + groupScaleDim);
             jac.block(
@@ -4881,7 +4882,6 @@ ScaleAndFitResult MarkerFitter::scaleAndFit(
                 = expNegLogPdfGradient.transpose();
           }
           assert(jac.rows() == outputDim);
-
         },
         // Generate a random restart position
         [&skeletonBallJoints, &skeleton, &observedJoints](

--- a/unittests/unit/test_DynamicsFitter.cpp
+++ b/unittests/unit/test_DynamicsFitter.cpp
@@ -6625,7 +6625,7 @@ TEST(DynamicsFitter, CARMAGO_TEST)
       grfFiles,
       -1,
       0,
-      true,
+      false,
       true);
 }
 #endif


### PR DESCRIPTION
On the Carmago dataset on dev, if you forget to tick the "my model has no arms" box, you can still hang the dev server. That's because the system will happily enter a loop marking more and more timesteps as "missing GRF" because of "unmeasured external torque".

This patch adds back-off logic where we automatically switch to a reaction-wheels formula if we find ourselves marking too many timesteps as missing GRF for unmeasured external torque.