### PR TITLE
Improve height matching

### DIFF
--- a/dart/biomechanics/MarkerFitter.hpp
+++ b/dart/biomechanics/MarkerFitter.hpp
@@ -782,6 +782,14 @@ public:
   void setAnthropometricPrior(
       std::shared_ptr<biomechanics::Anthropometrics> prior, s_t weight = 0.001);
 
+  /// This sets the height (in meters) that the model should be scaled to, and
+  /// the weight we should use when enforcing that scaling. This is in some
+  /// sense redundant to the anthropometric prior, but it's useful to have a
+  /// separate term for this, because it allows us to weight the height
+  /// constraint more heavily, because it's closer to a "hard constraint" than
+  /// the other anthropometric priors.
+  void setExplicitHeightPrior(s_t height, s_t weight = 0.001);
+
   /// This sets the data from a static trial, which we can use to resolve some
   /// forms of pelvis and foot ambiguity.
   void setStaticTrial(
@@ -1006,6 +1014,11 @@ protected:
   /// add its log-PDF to standard loss
   std::shared_ptr<biomechanics::Anthropometrics> mAnthropometrics;
   s_t mAnthropometricWeight;
+
+  /// This is an optional prior to use when scaling the skeleton, to ensure that
+  /// the height matches what the user expects.
+  s_t mHeightPrior;
+  s_t mHeightPriorWeight;
 
   /// This is an optional prior for a static pose trial, which can be used to
   /// help address ambiguity about feet and pelvis offsets

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -2688,6 +2688,17 @@ Eigen::VectorXs Skeleton::finiteDifferenceGradientOfHeightWrtBodyScales(
 }
 
 //==============================================================================
+/// This computes the gradient of the height
+Eigen::VectorXs Skeleton::getGradientOfHeightWrtGroupScales(
+    Eigen::VectorXs pose, Eigen::Vector3s up)
+{
+  Eigen::VectorXs wrtBodyScales = getGradientOfHeightWrtBodyScales(pose, up);
+  Eigen::VectorXs result
+      = convertBodyScalesGradientToGroupScales(wrtBodyScales);
+  return result;
+}
+
+//==============================================================================
 /// This returns a marker set with at least one marker in it, that each
 /// represents the lowest point on the body, measure by the `up` vector, in
 /// the specified position. If there are no ties, this will be of length 1. If

--- a/dart/dynamics/Skeleton.hpp
+++ b/dart/dynamics/Skeleton.hpp
@@ -773,6 +773,10 @@ public:
   Eigen::VectorXs finiteDifferenceGradientOfHeightWrtBodyScales(
       Eigen::VectorXs pose, Eigen::Vector3s up = Eigen::Vector3s::UnitY());
 
+  /// This computes the gradient of the height
+  Eigen::VectorXs getGradientOfHeightWrtGroupScales(
+      Eigen::VectorXs pose, Eigen::Vector3s up = Eigen::Vector3s::UnitY());
+
   /// This returns a marker set with at least one marker in it, that each
   /// represents the lowest point on the body, measure by the `up` vector, in
   /// the specified position. If there are no ties, this will be of length 1. If

--- a/python/_nimblephysics/biomechanics/MarkerFitter.cpp
+++ b/python/_nimblephysics/biomechanics/MarkerFitter.cpp
@@ -263,6 +263,11 @@ void MarkerFitter(py::module& m)
           ::py::arg("prior"),
           ::py::arg("weight") = 0.001)
       .def(
+          "setExplicitHeightPrior",
+          &dart::biomechanics::MarkerFitter::setExplicitHeightPrior,
+          ::py::arg("prior"),
+          ::py::arg("weight") = 1e3)
+      .def(
           "setStaticTrial",
           &dart::biomechanics::MarkerFitter::setStaticTrial,
           ::py::arg("markerObservationsMapAtStaticPose"),

--- a/unittests/unit/test_MarkerFitter.cpp
+++ b/unittests/unit/test_MarkerFitter.cpp
@@ -1671,7 +1671,6 @@ std::vector<MarkerInitialization> runEngine(
       2);
 
   Eigen::VectorXs pose = Eigen::VectorXs::Zero(standard.skeleton->getNumDofs());
-  pose(4) = 0.94;
   s_t gotHeight = standard.skeleton->getHeight(pose);
   std::cout << "Target height: " << heightM << "m" << std::endl;
   std::cout << "Final height: " << gotHeight << "m" << std::endl;

--- a/unittests/unit/test_MarkerFitter.cpp
+++ b/unittests/unit/test_MarkerFitter.cpp
@@ -1502,6 +1502,8 @@ std::vector<MarkerInitialization> runEngine(
   anthropometrics->setDistribution(gauss);
   fitter.setAnthropometricPrior(anthropometrics, 0.1);
 
+  fitter.setExplicitHeightPrior(heightM, 1e3);
+
   (void)staticPoseMarkers;
   (void)staticPose;
   if (staticPoseMarkers.size() > 0)
@@ -1667,6 +1669,12 @@ std::vector<MarkerInitialization> runEngine(
       "./_id_setup.xml",
       0,
       2);
+
+  Eigen::VectorXs pose = Eigen::VectorXs::Zero(standard.skeleton->getNumDofs());
+  pose(4) = 0.94;
+  s_t gotHeight = standard.skeleton->getHeight(pose);
+  std::cout << "Target height: " << heightM << "m" << std::endl;
+  std::cout << "Final height: " << gotHeight << "m" << std::endl;
 
   if (saveGUI)
   {
@@ -5715,6 +5723,42 @@ TEST(MarkerFitter, SINGLE_TRIAL_MICHAEL)
       59,
       1.72,
       "female");
+}
+#endif
+
+#ifdef ALL_TESTS
+TEST(MarkerFitter, SAM_DATA)
+{
+  std::vector<std::string> c3dFiles;
+  std::vector<std::string> trcFiles;
+  std::vector<std::string> grfFiles;
+  trcFiles.push_back(
+      "dart://sample/grf/Hamner_subject17/trials/run200/markers.trc");
+  trcFiles.push_back(
+      "dart://sample/grf/Hamner_subject17/trials/run300/markers.trc");
+  trcFiles.push_back(
+      "dart://sample/grf/Hamner_subject17/trials/run400/markers.trc");
+  trcFiles.push_back(
+      "dart://sample/grf/Hamner_subject17/trials/run500/markers.trc");
+  grfFiles.push_back(
+      "dart://sample/grf/Hamner_subject17/trials/run200/grf.mot");
+  grfFiles.push_back(
+      "dart://sample/grf/Hamner_subject17/trials/run300/grf.mot");
+  grfFiles.push_back(
+      "dart://sample/grf/Hamner_subject17/trials/run400/grf.mot");
+  grfFiles.push_back(
+      "dart://sample/grf/Hamner_subject17/trials/run500/grf.mot");
+
+  runEngine(
+      "dart://sample/grf/Hamner_subject17/"
+      "unscaled_generic.osim",
+      c3dFiles,
+      trcFiles,
+      grfFiles,
+      68.45,
+      1.68,
+      "male",
+      true);
 }
 #endif
 


### PR DESCRIPTION
This PR improves the quality of results in several ways:

- Primarily, we add a `fitter.setExplicitHeightPrior(heightM, weightOfPrior = 1e3)` method to `MarkerFitter` that can be used to add a term to track the subject height explicitly (at a much higher weight than the rest of the anthropometric prior)
  - This term gets incorporated both in the initial scale+fit steps, as well as the final bilevel optimization
- We also improve the quality of the joint center and joint axis fits
- Also minor improvements to the initial IK steps, with better root positions during random restarts