### PR TITLE
Upgrading the way force plates are assigned to feet

### DIFF
--- a/dart/biomechanics/DynamicsFitter.cpp
+++ b/dart/biomechanics/DynamicsFitter.cpp
@@ -19,6 +19,7 @@
 #include <coin/IpIpoptApplication.hpp>
 #include <coin/IpSolveStatistics.hpp>
 #include <coin/IpTNLP.hpp>
+#include <sys/param.h>
 
 #include "dart/biomechanics/C3DForcePlatforms.hpp"
 #include "dart/biomechanics/ForcePlate.hpp"
@@ -8767,11 +8768,14 @@ std::shared_ptr<DynamicsInitialization> DynamicsFitter::createInitialization(
     std::vector<Eigen::MatrixXs> poseTrials,
     std::vector<int> framesPerSecond,
     std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
-        markerObservationTrials)
+        markerObservationTrials,
+    std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment)
 {
   std::shared_ptr<DynamicsInitialization> init
       = std::make_shared<DynamicsInitialization>();
   init->forcePlateTrials = forcePlateTrials;
+  init->overrideForcePlateToGRFNodeAssignment
+      = overrideForcePlateToGRFNodeAssignment;
 
   bool anyAntiparallel = false;
   for (int trial = 0; trial < init->forcePlateTrials.size(); trial++)
@@ -9064,7 +9068,8 @@ std::shared_ptr<DynamicsInitialization> DynamicsFitter::createInitialization(
     std::vector<std::vector<ForcePlate>> forcePlateTrials,
     std::vector<int> framesPerSecond,
     std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
-        markerObservationTrials)
+        markerObservationTrials,
+    std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment)
 {
   if (markerObservationTrials.size() != kinematicInit.size())
   {
@@ -9100,7 +9105,8 @@ std::shared_ptr<DynamicsInitialization> DynamicsFitter::createInitialization(
       forcePlateTrials,
       poseTrials,
       framesPerSecond,
-      markerObservationTrials);
+      markerObservationTrials,
+      overrideForcePlateToGRFNodeAssignment);
 
   // Copy over the initial body scaling
   init->groupScales = kinematicInit[0].groupScales;
@@ -10002,7 +10008,8 @@ void DynamicsFitter::addJointBoundSlack(
 // 0. Smooth the accelerations.
 void DynamicsFitter::smoothAccelerations(
     std::shared_ptr<DynamicsInitialization> init,
-    s_t smoothingWeight, s_t regularizationWeight)
+    s_t smoothingWeight,
+    s_t regularizationWeight)
 {
   const Eigen::VectorXs posUpperBound = mSkeleton->getPositionUpperLimits();
   const Eigen::VectorXs posLowerBound = mSkeleton->getPositionLowerLimits();
@@ -10029,9 +10036,12 @@ void DynamicsFitter::smoothAccelerations(
         }
       }
     }
-    AccelerationSmoother smoother(init->poseTrials[trial].cols(),
-                                  smoothingWeight, regularizationWeight,
-                                  false, false);
+    AccelerationSmoother smoother(
+        init->poseTrials[trial].cols(),
+        smoothingWeight,
+        regularizationWeight,
+        false,
+        false);
 
     init->poseTrials[trial] = smoother.smooth(init->poseTrials[trial]);
 
@@ -13117,7 +13127,7 @@ void DynamicsFitter::recomputeGRFs(
 
   init->grfTrials[trial].setZero();
 
-  // Precompute the foot locations over time
+  // 1. Precompute the foot locations over time
   std::vector<std::vector<Eigen::Vector3s>> footLocations;
   for (int t = 0; t < poses.cols(); t++)
   {
@@ -13134,108 +13144,196 @@ void DynamicsFitter::recomputeGRFs(
     footLocations.push_back(footLocationsThisTimestep);
   }
 
+  // 2. Assign force plates to feet
   for (int i = 0; i < forcePlates.size(); i++)
   {
-    int lastStartedTrack = -1;
-    Eigen::VectorXs sumSquaredDistances
-        = Eigen::VectorXs::Zero(init->grfBodyNodes.size());
-
-    for (int t = 0; t < poses.cols(); t++)
+    // 2.0. If there is a manual override on force plate assignment, respect
+    // that above all else
+    if (init->overrideForcePlateToGRFNodeAssignment.size() > trial
+        && init->overrideForcePlateToGRFNodeAssignment[trial].size() > i
+        && init->overrideForcePlateToGRFNodeAssignment[trial][i] != -1)
     {
-      Eigen::Vector3s force = forcePlates[i].forces[t];
-      Eigen::Vector3s moments = forcePlates[i].moments[t];
-      Eigen::Vector3s cop = forcePlates[i].centersOfPressure[t];
-
-      // Timesteps where the force plate has a 0 force (we use 3 newtons
-      // as our threshold), don't need to be assigned to anything
-      if (force.norm() < 3.0 || force.hasNaN() || cop.hasNaN()
-          || moments.hasNaN())
+      for (int t = 0; t < poses.cols(); t++)
       {
-        if (lastStartedTrack > -1)
+        init->forcePlatesAssignedToContactBody[trial][i][t]
+            = init->overrideForcePlateToGRFNodeAssignment[trial][i];
+      }
+    }
+    else
+    {
+      // 2.1. Go through all the timesteps, and assign the force plate to a foot
+      // throughout time.
+      for (int t = 0; t < poses.cols(); t++)
+      {
+        init->forcePlatesAssignedToContactBody[trial][i][t] = -1;
+      }
+      int lastStartedTrack = -1;
+      Eigen::VectorXs sumSquaredDistances
+          = Eigen::VectorXs::Zero(init->grfBodyNodes.size());
+      for (int t = 0; t < poses.cols(); t++)
+      {
+        Eigen::Vector3s force = forcePlates[i].forces[t];
+        Eigen::Vector3s moments = forcePlates[i].moments[t];
+        Eigen::Vector3s cop = forcePlates[i].centersOfPressure[t];
+
+        // Timesteps where the force plate has a 0 force (we use 3 newtons
+        // as our threshold), don't need to be assigned to anything at this
+        // stage
+        if (force.norm() < 3.0 || force.hasNaN() || cop.hasNaN()
+            || moments.hasNaN())
         {
-          Eigen::Index closestFoot;
-          sumSquaredDistances.minCoeff(&closestFoot);
-
-          // std::cout << "Force Plate " << i << " time range ["
-          //           << lastStartedTrack << "," << (t - 1)
-          //           << "] Closest foot: " << closestFoot << " with
-          //           distances
-          //           "
-          //           << sumSquaredDistances.transpose() << std::endl;
-
-          // Now assign everything in that track to the foot that was closest
-          // over the whole track
-          for (int assignT = lastStartedTrack; assignT < t; assignT++)
+          if (lastStartedTrack > -1)
           {
-            // This is a map of [trial][forcePlate][timestep]
-            init->forcePlatesAssignedToContactBody[trial][i][assignT]
-                = closestFoot;
+            Eigen::Index closestFoot;
+            sumSquaredDistances.minCoeff(&closestFoot);
 
-            Eigen::Vector3s force = forcePlates[i].forces[assignT];
-            Eigen::Vector3s cop = forcePlates[i].centersOfPressure[assignT];
-            Eigen::Vector3s moments = forcePlates[i].moments[assignT];
+            // std::cout << "Force Plate " << i << " time range ["
+            //           << lastStartedTrack << "," << (t - 1)
+            //           << "] Closest foot: " << closestFoot << " with
+            //           distances
+            //           "
+            //           << sumSquaredDistances.transpose() << std::endl;
 
-            Eigen::Vector6s wrench = Eigen::Vector6s::Zero();
-            wrench.head<3>() = moments;
-            wrench.tail<3>() = force;
-            Eigen::Isometry3s wrenchT = Eigen::Isometry3s::Identity();
-            wrenchT.translation() = cop;
-            Eigen::Vector6s worldWrench = math::dAdInvT(wrenchT, wrench);
-
-            // If multiple force plates assign to the same foot, sum up the
-            // forces
-            init->grfTrials[trial].block<6, 1>(closestFoot * 6, assignT)
-                += worldWrench;
+            // Now assign everything in that track to the foot that was closest
+            // over the whole track
+            for (int assignT = lastStartedTrack; assignT < t; assignT++)
+            {
+              // This is a map of [trial][forcePlate][timestep]
+              init->forcePlatesAssignedToContactBody[trial][i][assignT]
+                  = closestFoot;
+            }
           }
+          lastStartedTrack = -1;
+          sumSquaredDistances.setZero();
+          continue;
         }
-        lastStartedTrack = -1;
-        sumSquaredDistances.setZero();
-        continue;
+
+        if (lastStartedTrack == -1)
+          lastStartedTrack = t;
+        for (int b = 0; b < init->grfBodyNodes.size(); b++)
+        {
+          sumSquaredDistances(b) += (footLocations[t][b] - cop).squaredNorm();
+        }
       }
 
-      if (lastStartedTrack == -1)
-        lastStartedTrack = t;
-      for (int b = 0; b < init->grfBodyNodes.size(); b++)
+      // Do one last pass, in case we ended the trajectory with active contact
+      if (lastStartedTrack > -1)
       {
-        sumSquaredDistances(b) += (footLocations[t][b] - cop).squaredNorm();
+        Eigen::Index closestFoot;
+        sumSquaredDistances.minCoeff(&closestFoot);
+
+        // std::cout << "Force Plate " << i << " time range [" <<
+        // lastStartedTrack
+        //           << "," << (poses.cols() - 1)
+        //           << "] Closest foot: " << closestFoot << " with distances "
+        //           << sumSquaredDistances.transpose() << std::endl;
+
+        // Now assign everything in that track to the foot that was closest
+        // over the whole track
+        for (int assignT = lastStartedTrack; assignT < poses.cols(); assignT++)
+        {
+          // This is a map of [trial][forcePlate][timestep]
+          init->forcePlatesAssignedToContactBody[trial][i][assignT]
+              = closestFoot;
+        }
+      }
+
+      // 2.2. Check if this force plate is only ever assigned to a single foot
+      // (which is great) and if so, then assign all timesteps to that foot.
+      std::vector<int> assignedToFeet;
+      for (int t = 0; t < poses.cols(); t++)
+      {
+        int closestFoot = init->forcePlatesAssignedToContactBody[trial][i][t];
+        if (closestFoot != -1)
+        {
+          // If closestFoot is already in the list, add it to the list
+          if (std::find(
+                  assignedToFeet.begin(), assignedToFeet.end(), closestFoot)
+              == assignedToFeet.end())
+          {
+            assignedToFeet.push_back(closestFoot);
+          }
+        }
+      }
+
+      if (assignedToFeet.size() == 0)
+      {
+        // This force plate is never assigned to a foot, so we can't do anything
+        std::cout << "NOTE: Assigning force plate " << i
+                  << " to no feet during trial " << trial
+                  << ", because there was never sufficient measured force on "
+                     "the plate"
+                  << std::endl;
+      }
+      else if (assignedToFeet.size() == 1)
+      {
+        std::cout << "Assigning force plate " << i << " to foot "
+                  << assignedToFeet[0] << " on trial " << trial << std::endl;
+        // This force plate is only ever assigned to a single foot, so we can
+        // assign all timesteps to that foot
+        for (int t = 0; t < poses.cols(); t++)
+        {
+          // This is a map of [trial][forcePlate][timestep]
+          init->forcePlatesAssignedToContactBody[trial][i][t]
+              = assignedToFeet[0];
+        }
+      }
+      else
+      {
+        std::cout << "NOTE: Assigning force plate " << i
+                  << " to multiple feet during trial " << trial << std::endl;
+        // This force plate is assigned to multiple feet over time. This can
+        // often happen with foot-crossing. We won't issue a warning, but we can
+        // go through and try to fill in the gaps between feet assignments that
+        // are the same.
+        int lastContactIndex = -1;
+        for (int t = 0; t < poses.cols(); t++)
+        {
+          int closestFoot = init->forcePlatesAssignedToContactBody[trial][i][t];
+          if (closestFoot != -1)
+          {
+            // If we find a gap (filled with -1's) where the contact foot on
+            // both ends is the same, then we can fill it in
+            if (lastContactIndex != -1
+                && init->forcePlatesAssignedToContactBody[trial][i]
+                                                         [lastContactIndex]
+                       == closestFoot)
+            {
+              for (int fillT = lastContactIndex + 1; fillT < t; fillT++)
+              {
+                assert(
+                    init->forcePlatesAssignedToContactBody[trial][i][fillT]
+                    == -1);
+                init->forcePlatesAssignedToContactBody[trial][i][fillT]
+                    = closestFoot;
+              }
+            }
+            lastContactIndex = t;
+          }
+        }
       }
     }
 
-    // Do one last pass, in case we ended the trajectory with active contact
-    if (lastStartedTrack > -1)
+    // 2.3. Compute the actual wrenches for the foot assignment(s) we've made
+    for (int t = 0; t < poses.cols(); t++)
     {
-      Eigen::Index closestFoot;
-      sumSquaredDistances.minCoeff(&closestFoot);
+      // This is a map of [trial][forcePlate][timestep]
+      int closestFoot = init->forcePlatesAssignedToContactBody[trial][i][t];
 
-      // std::cout << "Force Plate " << i << " time range [" <<
-      // lastStartedTrack
-      //           << "," << (poses.cols() - 1)
-      //           << "] Closest foot: " << closestFoot << " with distances "
-      //           << sumSquaredDistances.transpose() << std::endl;
+      Eigen::Vector3s force = forcePlates[i].forces[t];
+      Eigen::Vector3s cop = forcePlates[i].centersOfPressure[t];
+      Eigen::Vector3s moments = forcePlates[i].moments[t];
 
-      // Now assign everything in that track to the foot that was closest
-      // over the whole track
-      for (int assignT = lastStartedTrack; assignT < poses.cols(); assignT++)
-      {
-        // This is a map of [trial][forcePlate][timestep]
-        init->forcePlatesAssignedToContactBody[trial][i][assignT] = closestFoot;
+      Eigen::Vector6s wrench = Eigen::Vector6s::Zero();
+      wrench.head<3>() = moments;
+      wrench.tail<3>() = force;
+      Eigen::Isometry3s wrenchT = Eigen::Isometry3s::Identity();
+      wrenchT.translation() = cop;
+      Eigen::Vector6s worldWrench = math::dAdInvT(wrenchT, wrench);
 
-        Eigen::Vector3s force = forcePlates[i].forces[assignT];
-        Eigen::Vector3s cop = forcePlates[i].centersOfPressure[assignT];
-        Eigen::Vector3s moments = forcePlates[i].moments[assignT];
-
-        Eigen::Vector6s wrench = Eigen::Vector6s::Zero();
-        wrench.head<3>() = moments;
-        wrench.tail<3>() = force;
-        Eigen::Isometry3s wrenchT = Eigen::Isometry3s::Identity();
-        wrenchT.translation() = cop;
-        Eigen::Vector6s worldWrench = math::dAdInvT(wrenchT, wrench);
-
-        // If multiple force plates assign to the same foot, sum up the
-        // forces
-        init->grfTrials[trial].block<6, 1>(closestFoot * 6, assignT)
-            += worldWrench;
-      }
+      // If multiple force plates assign to the same foot, sum up the
+      // forces
+      init->grfTrials[trial].block<6, 1>(closestFoot * 6, t) += worldWrench;
     }
   }
 }

--- a/dart/biomechanics/DynamicsFitter.hpp
+++ b/dart/biomechanics/DynamicsFitter.hpp
@@ -1254,6 +1254,10 @@ public:
       std::vector<int> framesPerSecond,
       std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
           markerObservationTrials,
+      /// This argument takes a list over trials, where each trial is a list of
+      /// integers, one-per-force-plate, where each integer is the index of the
+      /// GRF node to assign that force plate to, or -1 to just rely on the
+      /// automated assignment algorithm
       std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment
       = std::vector<std::vector<int>>());
 
@@ -1267,6 +1271,10 @@ public:
       std::vector<int> framesPerSecond,
       std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
           markerObservationTrials,
+      /// This argument takes a list over trials, where each trial is a list of
+      /// integers, one-per-force-plate, where each integer is the index of the
+      /// GRF node to assign that force plate to, or -1 to just rely on the
+      /// automated assignment algorithm
       std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment
       = std::vector<std::vector<int>>());
 

--- a/dart/biomechanics/DynamicsFitter.hpp
+++ b/dart/biomechanics/DynamicsFitter.hpp
@@ -1256,8 +1256,13 @@ public:
           markerObservationTrials,
       /// This argument takes a list over trials, where each trial is a list of
       /// integers, one-per-force-plate, where each integer is the index of the
-      /// GRF node to assign that force plate to, or -1 to just rely on the
-      /// automated assignment algorithm
+      /// corresponding entry in `grfNodes` to assign that force plate to, or -1
+      /// to just rely on the automated assignment algorithm. For example, if
+      /// `grfNodes` is [left_foot, right_foot], and we have only one trial with
+      /// two force plates, and wish to assign the first force plate to the
+      /// right_foot, and second to the left_foot, we would pass in [[1, 0]].
+      /// For two trials, where the second trial we wish to use automatic
+      /// assignment, we could pass [[1,0], [-1,-1]].
       std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment
       = std::vector<std::vector<int>>());
 
@@ -1273,8 +1278,13 @@ public:
           markerObservationTrials,
       /// This argument takes a list over trials, where each trial is a list of
       /// integers, one-per-force-plate, where each integer is the index of the
-      /// GRF node to assign that force plate to, or -1 to just rely on the
-      /// automated assignment algorithm
+      /// corresponding entry in `grfNodes` to assign that force plate to, or -1
+      /// to just rely on the automated assignment algorithm. For example, if
+      /// `grfNodes` is [left_foot, right_foot], and we have only one trial with
+      /// two force plates, and wish to assign the first force plate to the
+      /// right_foot, and second to the left_foot, we would pass in [[1, 0]].
+      /// For two trials, where the second trial we wish to use automatic
+      /// assignment, we could pass [[1,0], [-1,-1]].
       std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment
       = std::vector<std::vector<int>>());
 

--- a/dart/biomechanics/DynamicsFitter.hpp
+++ b/dart/biomechanics/DynamicsFitter.hpp
@@ -771,8 +771,6 @@ protected:
   std::shared_ptr<dynamics::Skeleton> mSkel;
 };
 
-
-
 /**
  * We create a single initialization object, and pass it around to optimization
  * problems to re-use, because it's not super cheap to construct.
@@ -782,6 +780,7 @@ struct DynamicsInitialization
   ///////////////////////////////////////////
   // Inputs from files
   std::vector<std::vector<ForcePlate>> forcePlateTrials;
+  std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment;
   std::vector<Eigen::MatrixXs> originalPoses;
   std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
       markerObservationTrials;
@@ -1254,7 +1253,9 @@ public:
       std::vector<Eigen::MatrixXs> poseTrials,
       std::vector<int> framesPerSecond,
       std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
-          markerObservationTrials);
+          markerObservationTrials,
+      std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment
+      = std::vector<std::vector<int>>());
 
   // This creates an optimization problem from a kinematics initialization
   static std::shared_ptr<DynamicsInitialization> createInitialization(
@@ -1265,7 +1266,9 @@ public:
       std::vector<std::vector<ForcePlate>> forcePlateTrials,
       std::vector<int> framesPerSecond,
       std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
-          markerObservationTrials);
+          markerObservationTrials,
+      std::vector<std::vector<int>> overrideForcePlateToGRFNodeAssignment
+      = std::vector<std::vector<int>>());
 
   // This retargets a dynamics initialization to another skeleton
   static std::shared_ptr<DynamicsInitialization> retargetInitialization(
@@ -1302,8 +1305,9 @@ public:
   // 0. Estimate when each foot is in contact with the ground, which we can use
   // to infer when we're missing GRF data on certain timesteps, so we don't let
   // it mess with our optimization.
-  void estimateFootGroundContacts(std::shared_ptr<DynamicsInitialization> init,
-                                  bool ignoreFootNotOverForcePlate = false);
+  void estimateFootGroundContacts(
+      std::shared_ptr<DynamicsInitialization> init,
+      bool ignoreFootNotOverForcePlate = false);
 
   // 0. This goes through and marks any "impact" GRF timesteps (defined as
   // `windowLen` steps after the first non-zero step after a flight phase with
@@ -1331,9 +1335,10 @@ public:
       std::shared_ptr<dynamics::Skeleton> skel, s_t slack = 0.1);
 
   // 0. Smooth the accelerations.
-  void smoothAccelerations(std::shared_ptr<DynamicsInitialization> init,
-                           s_t smoothingWeight = 1e1,
-                           s_t regularizationWeight = 1e-3);
+  void smoothAccelerations(
+      std::shared_ptr<DynamicsInitialization> init,
+      s_t smoothingWeight = 1e1,
+      s_t regularizationWeight = 1e-3);
 
   // 0. Estimate which timesteps probably have unmeasured external forces
   // present. By passing a number smaller than 1.0 to scaleThresholds, we can

--- a/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
+++ b/python/_nimblephysics/biomechanics/DynamicsFitter.cpp
@@ -485,7 +485,9 @@ protected:
               std::vector<Eigen::MatrixXs> poseTrials,
               std::vector<int> framesPerSecond,
               std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
-                  markerObservationTrials)
+                  markerObservationTrials,
+              std::vector<std::vector<int>>
+                  overrideForcePlateToGRFNodeAssignment)
               -> std::shared_ptr<dart::biomechanics::DynamicsInitialization> {
             return dart::biomechanics::DynamicsFitter::createInitialization(
                 skel,
@@ -495,7 +497,8 @@ protected:
                 forcePlateTrials,
                 poseTrials,
                 framesPerSecond,
-                markerObservationTrials);
+                markerObservationTrials,
+                overrideForcePlateToGRFNodeAssignment);
           },
           ::py::arg("skel"),
           ::py::arg("markerMap"),
@@ -504,7 +507,9 @@ protected:
           ::py::arg("forcePlateTrials"),
           ::py::arg("poseTrials"),
           ::py::arg("framesPerSecond"),
-          ::py::arg("markerObservationTrials"))
+          ::py::arg("markerObservationTrials"),
+          ::py::arg("overrideForcePlateToGRFNodeAssignment")
+          = std::vector<std::vector<int>>())
       .def_static(
           "createInitialization",
           +[](std::shared_ptr<dynamics::Skeleton> skel,
@@ -516,7 +521,9 @@ protected:
                   forcePlateTrials,
               std::vector<int> framesPerSecond,
               std::vector<std::vector<std::map<std::string, Eigen::Vector3s>>>
-                  markerObservationTrials)
+                  markerObservationTrials,
+              std::vector<std::vector<int>>
+                  overrideForcePlateToGRFNodeAssignment)
               -> std::shared_ptr<dart::biomechanics::DynamicsInitialization> {
             return dart::biomechanics::DynamicsFitter::createInitialization(
                 skel,
@@ -525,7 +532,8 @@ protected:
                 grfNodes,
                 forcePlateTrials,
                 framesPerSecond,
-                markerObservationTrials);
+                markerObservationTrials,
+                overrideForcePlateToGRFNodeAssignment);
           },
           ::py::arg("skel"),
           ::py::arg("kinematicInits"),
@@ -533,7 +541,9 @@ protected:
           ::py::arg("grfNodes"),
           ::py::arg("forcePlateTrials"),
           ::py::arg("framesPerSecond"),
-          ::py::arg("markerObservationTrials"))
+          ::py::arg("markerObservationTrials"),
+          ::py::arg("overrideForcePlateToGRFNodeAssignment")
+          = std::vector<std::vector<int>>())
       .def(
           "comPositions",
           &dart::biomechanics::DynamicsFitter::comPositions,

--- a/unittests/unit/test_DynamicsFitter.cpp
+++ b/unittests/unit/test_DynamicsFitter.cpp
@@ -6501,6 +6501,40 @@ TEST(DynamicsFitter, HamnerMultipleTrials)
 #endif
 
 #ifdef ALL_TESTS
+TEST(DynamicsFitter, GRFBlipTest)
+{
+  std::vector<std::string> motFiles;
+  std::vector<std::string> c3dFiles;
+  std::vector<std::string> trcFiles;
+  std::vector<std::string> grfFiles;
+
+  std::string prefix = "dart://sample/grf/GRFBlipTest1/";
+  trcFiles.push_back(prefix + "MarkerData/markers.trc");
+  grfFiles.push_back(prefix + "ID/markers_grf.mot");
+  motFiles.push_back(prefix + "IK/markers_ik.mot");
+
+  std::vector<std::string> footNames;
+  footNames.push_back("calcn_r");
+  footNames.push_back("calcn_l");
+
+  int maxTrialsToSolveMassOver = 1;
+  runEngine(
+      "dart://sample/grf/GRFBlipTest1/Models/final.osim",
+      footNames,
+      motFiles,
+      c3dFiles,
+      trcFiles,
+      grfFiles,
+      -1,
+      0,
+      false,
+      false,
+      false,
+      maxTrialsToSolveMassOver);
+}
+#endif
+
+#ifdef ALL_TESTS
 TEST(DynamicsFitter, MARKERS_TO_DYNAMICS_OPENCAP)
 {
   std::string subjectName = "Subject4";


### PR DESCRIPTION
This PR does several things to improve the way force plates are assigned to feet.

1) It allows manual mapping of force plates to feet, if the user wants to override the automatic system
2) It does its best to assign a force plate to a single foot for the whole trial, if at all possible
3) If feet cross force plates during the trial, it will still attempt to assign sections of "no contact" time to a foot, if the foot in contact with the force plates before and after the "no contact" phase is the same foot.