### PR TITLE
Stability for initial IK + flags to disable marker post-processing

### DIFF
--- a/dart/biomechanics/MarkerFitter.hpp
+++ b/dart/biomechanics/MarkerFitter.hpp
@@ -939,13 +939,16 @@ public:
   /// This sets the map of IMUs to their locations on body segments
   void setImuMap(dynamics::SensorMap imuMap);
 
-  /// This returns (a copy of) the map of IMUs to their locations on body segments
+  /// This returns (a copy of) the map of IMUs to their locations on body
+  /// segments
   dynamics::SensorMap getImuMap();
 
-  /// This returns (a copy of) the list of IMUs to their locations on body segments
+  /// This returns (a copy of) the list of IMUs to their locations on body
+  /// segments
   std::vector<std::pair<dynamics::BodyNode*, Eigen::Isometry3s>> getImuList();
 
-  /// This returns (a copy of) the list of IMU names, corresponding to the getImuList() IMUs
+  /// This returns (a copy of) the list of IMU names, corresponding to the
+  /// getImuList() IMUs
   std::vector<std::string> getImuNames();
 
   /// This calculates the best-fit rotation for the IMUs that were passed in, to
@@ -1147,6 +1150,18 @@ public:
   /// penality for going below the threshold distance. That would be hard to
   /// optimize, so don't make it too small.
   void setJointForceFieldSoftness(s_t softness);
+
+  /// If we set this to true, then after the main optimization completes we will
+  /// do a final step to "center" the error of the anatomical markers. This
+  /// minimizes marker RMSE, but does NOT respect the weights about how far
+  /// markers should be allowed to move.
+  void setPostprocessAnatomicalMarkerOffsets(bool postprocess);
+
+  /// If we set this to true, then after the main optimization completes we will
+  /// do a final step to "center" the error of the tracking markers. This
+  /// minimizes marker RMSE, but does NOT respect the weights about how far
+  /// markers should be allowed to move.
+  void setPostprocessTrackingMarkerOffsets(bool postprocess);
 
   /// Sets the loss and gradient function
   void setCustomLossAndGrad(
@@ -1397,6 +1412,11 @@ protected:
   s_t mStaticTrialWeight;
   s_t mJointForceFieldThresholdDistance;
   s_t mJointForceFieldSoftness;
+
+  // These flags control which markers get adjusted to "center" their errors
+  // after the main optimization is complete
+  bool mPostprocessAnatomicalMarkerOffsets;
+  bool mPostprocessTrackingMarkerOffsets;
 
   // These are IPOPT settings
   double mTolerance;

--- a/dart/math/IKSolver.cpp
+++ b/dart/math/IKSolver.cpp
@@ -204,14 +204,14 @@ s_t solveIK(
     IKConfig config)
 {
 #ifndef NDEBUG
-  verifyJacobian(
-      initialPos,
-      upperBound,
-      lowerBound,
-      targetSize,
-      setPosAndClamp,
-      eval,
-      config);
+  // verifyJacobian(
+  //     initialPos,
+  //     upperBound,
+  //     lowerBound,
+  //     targetSize,
+  //     setPosAndClamp,
+  //     eval,
+  //     config);
 #endif
 
   s_t bestError = std::numeric_limits<s_t>::infinity();
@@ -424,10 +424,9 @@ IKResult refineIK(
       {
         // Slowly grow LR while we're safely decreasing loss
         lr *= 1.1;
+        lastError = currentError;
       }
     }
-
-    lastError = currentError;
 
     /////////////////////////////////////////////////////////////////////////////
     // Do the actual IK update

--- a/python/_nimblephysics/biomechanics/MarkerFitter.cpp
+++ b/python/_nimblephysics/biomechanics/MarkerFitter.cpp
@@ -329,6 +329,28 @@ void MarkerFitter(py::module& m)
   optimize, so don't make it too small.
           )pydoc")
       .def(
+          "setPostprocessAnatomicalMarkerOffsets",
+          &dart::biomechanics::MarkerFitter::
+              setPostprocessAnatomicalMarkerOffsets,
+          ::py::arg("postprocess"),
+          R"pydoc(
+  If we set this to true, then after the main optimization completes we will
+  do a final step to "center" the error of the anatomical markers. This
+  minimizes marker RMSE, but does NOT respect the weights about how far
+  markers should be allowed to move.
+          )pydoc")
+      .def(
+          "setPostprocessTrackingMarkerOffsets",
+          &dart::biomechanics::MarkerFitter::
+              setPostprocessTrackingMarkerOffsets,
+          ::py::arg("postprocess"),
+          R"pydoc(
+  If we set this to true, then after the main optimization completes we will
+  do a final step to "center" the error of the tracking markers. This
+  minimizes marker RMSE, but does NOT respect the weights about how far
+  markers should be allowed to move.
+          )pydoc")
+      .def(
           "setCustomLossAndGrad",
           &dart::biomechanics::MarkerFitter::setCustomLossAndGrad,
           ::py::arg("loss"))
@@ -517,15 +539,9 @@ void MarkerFitter(py::module& m)
           "setImuMap",
           &dart::biomechanics::MarkerFitter::setImuMap,
           ::py::arg("imuMap"))
-      .def(
-          "getImuMap",
-          &dart::biomechanics::MarkerFitter::getImuMap)
-      .def(
-          "getImuList",
-          &dart::biomechanics::MarkerFitter::getImuList)
-      .def(
-          "getImuNames",
-          &dart::biomechanics::MarkerFitter::getImuNames)
+      .def("getImuMap", &dart::biomechanics::MarkerFitter::getImuMap)
+      .def("getImuList", &dart::biomechanics::MarkerFitter::getImuList)
+      .def("getImuNames", &dart::biomechanics::MarkerFitter::getImuNames)
       .def(
           "rotateIMUs",
           &dart::biomechanics::MarkerFitter::rotateIMUs,

--- a/unittests/unit/test_MarkerFitter.cpp
+++ b/unittests/unit/test_MarkerFitter.cpp
@@ -39,7 +39,7 @@
 
 // #define ALL_TESTS
 
-#define FUNCTIONAL_TESTS
+// #define FUNCTIONAL_TESTS
 
 using namespace dart;
 using namespace biomechanics;
@@ -1889,12 +1889,22 @@ std::vector<MarkerInitialization> runEngine(
     std::cout << "Saving trajectory..." << std::endl;
     std::cout << "FPS: " << framesPerSecond[0] << std::endl;
     std::cout << "Force plates len: " << forcePlates.size() << std::endl;
+    std::vector<std::map<std::string, Eigen::Vector3s>> accObs;
+    if (accObservations.size() > 0)
+    {
+      accObs = accObservations[0];
+    }
+    std::vector<std::map<std::string, Eigen::Vector3s>> gyroObs;
+    if (gyroObservations.size() > 0)
+    {
+      gyroObs = gyroObservations[0];
+    }
     fitter.saveTrajectoryAndMarkersToGUI(
         "../../../javascript/src/data/movement2.bin",
         results[0],
         markerObservationTrials[0],
-        accObservations[0],
-        gyroObservations[0],
+        accObs,
+        gyroObs,
         framesPerSecond[0],
         forcePlates[0]);
   }
@@ -5989,22 +5999,23 @@ TEST(MarkerFitter, SAM_DATA)
   std::vector<std::string> c3dFiles;
   std::vector<std::string> trcFiles;
   std::vector<std::string> grfFiles;
+  std::vector<std::string> imuFiles;
   trcFiles.push_back(
       "dart://sample/grf/Hamner_subject17/trials/run200/markers.trc");
-  trcFiles.push_back(
-      "dart://sample/grf/Hamner_subject17/trials/run300/markers.trc");
-  trcFiles.push_back(
-      "dart://sample/grf/Hamner_subject17/trials/run400/markers.trc");
-  trcFiles.push_back(
-      "dart://sample/grf/Hamner_subject17/trials/run500/markers.trc");
+  // trcFiles.push_back(
+  //     "dart://sample/grf/Hamner_subject17/trials/run300/markers.trc");
+  // trcFiles.push_back(
+  //     "dart://sample/grf/Hamner_subject17/trials/run400/markers.trc");
+  // trcFiles.push_back(
+  //     "dart://sample/grf/Hamner_subject17/trials/run500/markers.trc");
   grfFiles.push_back(
       "dart://sample/grf/Hamner_subject17/trials/run200/grf.mot");
-  grfFiles.push_back(
-      "dart://sample/grf/Hamner_subject17/trials/run300/grf.mot");
-  grfFiles.push_back(
-      "dart://sample/grf/Hamner_subject17/trials/run400/grf.mot");
-  grfFiles.push_back(
-      "dart://sample/grf/Hamner_subject17/trials/run500/grf.mot");
+  // grfFiles.push_back(
+  //     "dart://sample/grf/Hamner_subject17/trials/run300/grf.mot");
+  // grfFiles.push_back(
+  //     "dart://sample/grf/Hamner_subject17/trials/run400/grf.mot");
+  // grfFiles.push_back(
+  //     "dart://sample/grf/Hamner_subject17/trials/run500/grf.mot");
 
   runEngine(
       "dart://sample/grf/Hamner_subject17/"
@@ -6012,6 +6023,7 @@ TEST(MarkerFitter, SAM_DATA)
       c3dFiles,
       trcFiles,
       grfFiles,
+      imuFiles,
       68.45,
       1.68,
       "male",


### PR DESCRIPTION
This PR does two things:

1) It makes the initial IK scale+fit step somewhat more stable. Before we have joint center information, we now restrict the IK scale+fit problem by limiting the range of body scales that can be reached by the optimizer to +/- 10% around the scale implied by the height of the subject, and restricting all body nodes to scale uniformly.
2) It exposes flags to disable the post-optimization adjustment of anatomical markers and tracking markers separately. It defaults to _not_ adjusting the anatomical markers, but adjusting the tracking markers. This WILL NEGATIVELY IMPACT MARKER RMSE! But it will mean that <fixed> is really much more respected than it used to be.