### PR TITLE
Carefully debugging the ANSUR metrics and conditioning

### DIFF
--- a/dart/biomechanics/Anthropometrics.cpp
+++ b/dart/biomechanics/Anthropometrics.cpp
@@ -274,6 +274,21 @@ void Anthropometrics::debugToGUI(
 }
 
 //==============================================================================
+/// This prints a summary of each metric, and its relationship to its mean and
+/// variance, to the console
+void Anthropometrics::debugValues(std::shared_ptr<dynamics::Skeleton> skel)
+{
+  std::map<std::string, s_t> metrics = measure(skel);
+  std::cout << "Anthropometrics:" << std::endl;
+  for (auto& pair : metrics)
+  {
+    std::cout << "  " << pair.first << ": " << pair.second << " ~ N("
+              << mDist->getMean(pair.first) << ","
+              << mDist->getVariance(pair.first) << ")" << std::endl;
+  }
+}
+
+//==============================================================================
 void Anthropometrics::addMetric(
     std::string name,
     Eigen::VectorXs bodyPose,

--- a/dart/biomechanics/Anthropometrics.hpp
+++ b/dart/biomechanics/Anthropometrics.hpp
@@ -55,6 +55,10 @@ public:
       std::shared_ptr<server::GUIWebsocketServer> server,
       std::shared_ptr<dynamics::Skeleton> skel);
 
+  /// This prints a summary of each metric, and its relationship to its mean and
+  /// variance, to the console
+  void debugValues(std::shared_ptr<dynamics::Skeleton> skel);
+
   void addMetric(
       std::string name,
       Eigen::VectorXs bodyPose,

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -2638,6 +2638,9 @@ Eigen::VectorXs Skeleton::getGradientOfHeightWrtBodyScales(
     }
   }
 
+  // This can happen if the skeleton has no mesh shapes, in which case it will
+  // not have a "highest mesh vertex" and "lowest mesh vertex", because there
+  // are no vertices and no meshes.
   if (minBodyNode == nullptr || maxBodyNode == nullptr)
   {
     setPositions(originalPose);

--- a/dart/dynamics/Skeleton.cpp
+++ b/dart/dynamics/Skeleton.cpp
@@ -2638,6 +2638,12 @@ Eigen::VectorXs Skeleton::getGradientOfHeightWrtBodyScales(
     }
   }
 
+  if (minBodyNode == nullptr || maxBodyNode == nullptr)
+  {
+    setPositions(originalPose);
+    return Eigen::VectorXs::Zero(getNumBodyNodes() * 3);
+  }
+
   std::vector<std::pair<dynamics::BodyNode*, Eigen::Vector3s>> markers;
   markers.emplace_back(minBodyNode, minVertex);
   markers.emplace_back(maxBodyNode, maxVertex);

--- a/dart/math/MultivariateGaussian.cpp
+++ b/dart/math/MultivariateGaussian.cpp
@@ -71,6 +71,16 @@ s_t MultivariateGaussian::getMean(std::string variable)
   return 0.0;
 }
 
+s_t MultivariateGaussian::getVariance(std::string variable)
+{
+  for (int i = 0; i < mVars.size(); i++)
+  {
+    if (mVars[i] == variable)
+      return sqrt(mCov(i, i));
+  }
+  return 0.0;
+}
+
 Eigen::VectorXs MultivariateGaussian::convertFromMap(
     const std::map<std::string, s_t>& values)
 {
@@ -199,6 +209,8 @@ std::shared_ptr<MultivariateGaussian> MultivariateGaussian::condition(
   }
   Eigen::VectorXs subMu = mu_1 + cov_12 * cov_22_Inv * (observedVector - mu_2);
   Eigen::MatrixXs subCov = cov_11 - cov_12 * cov_22_Inv * cov_21;
+  assert(!subMu.hasNaN());
+  assert(!subCov.hasNaN());
 
   return std::make_shared<MultivariateGaussian>(subNames, subMu, subCov);
 }

--- a/dart/math/MultivariateGaussian.hpp
+++ b/dart/math/MultivariateGaussian.hpp
@@ -24,6 +24,8 @@ public:
 
   s_t getMean(std::string variable);
 
+  s_t getVariance(std::string variable);
+
   Eigen::VectorXs convertFromMap(const std::map<std::string, s_t>& values);
 
   std::map<std::string, s_t> convertToMap(const Eigen::VectorXs& values);

--- a/data/osim/ANSUR/ANSUR_metrics.xml
+++ b/data/osim/ANSUR/ANSUR_metrics.xml
@@ -18,7 +18,7 @@
     <Name>iliocristaleheight</Name>
     <MarkerA>
       <MeshNode>r_pelvis</MeshNode>
-      <Offset>-0.08 0.085 0.08</Offset>
+      <Offset>-0.08 0.06 0.08</Offset>
     </MarkerA>
     <MarkerB>
       <MeshNode>r_foot</MeshNode>
@@ -32,7 +32,7 @@
     <Name>crotchheight</Name>
     <MarkerA>
       <MeshNode>r_pelvis</MeshNode>
-      <Offset>0 -0.12 0.0</Offset>
+      <Offset>0 -0.15 0.0</Offset>
     </MarkerA>
     <MarkerB>
       <MeshNode>r_foot</MeshNode>
@@ -41,7 +41,7 @@
     <MeasureAlongAxis>0 1 0</MeasureAlongAxis>
     <BodyPose>0 0 0 0 0.94 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</BodyPose>
   </Metric>
-    <!-- (83) TROCHANTERION HEIGHT -->
+  <!-- (83) TROCHANTERION HEIGHT -->
   <Metric>
     <Name>trochanterionheight</Name>
     <MarkerA>
@@ -60,11 +60,11 @@
     <Name>bicristalbreadth</Name>
     <MarkerA>
       <MeshNode>r_pelvis</MeshNode>
-      <Offset>0.0 0.0 -0.13</Offset>
+      <Offset>0.0 0.0 -0.12</Offset>
     </MarkerA>
     <MarkerB>
       <MeshNode>l_pelvis</MeshNode>
-      <Offset>0.0 0.0 0.13</Offset>
+      <Offset>0.0 0.0 0.12</Offset>
     </MarkerB>
     <MeasureAlongAxis>0 0 0</MeasureAlongAxis>
     <BodyPose>0 0 0 0 0.94 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</BodyPose>
@@ -74,11 +74,11 @@
     <Name>waistdepth</Name>
     <MarkerA>
       <MeshNode>r_pelvis</MeshNode>
-      <Offset>0.10 0.08 0</Offset>
+      <Offset>0.09 0.08 0</Offset>
     </MarkerA>
     <MarkerB>
       <MeshNode>r_pelvis</MeshNode>
-      <Offset>-0.12 0.08 0.0</Offset>
+      <Offset>-0.11 0.08 0.0</Offset>
     </MarkerB>
     <MeasureAlongAxis>0 0 0</MeasureAlongAxis>
     <BodyPose>0 0 0 0 0.94 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</BodyPose>

--- a/unittests/unit/test_MarkerFitter.cpp
+++ b/unittests/unit/test_MarkerFitter.cpp
@@ -1708,6 +1708,11 @@ std::vector<MarkerInitialization> runEngine(
   std::map<std::string, s_t> observedValues;
   std::cout << "Anthro before conditioning:" << std::endl;
   gauss->debugToStdout();
+  // Annoyingly, the ANSUR dataset doesn't store the mass data as kg, it stores
+  // it as tenths of kgs, and it stores all distances in millimeters. For
+  // convenience, when we load the data from the CSV, we scale everything down
+  // by 0.001 (to do mm -> m conversion). To get the mass column back to kg, we
+  // need to multiply by 0.01.
   observedValues["weightkg"] = massKg * 0.01;
   observedValues["stature"] = heightM;
   gauss = gauss->condition(observedValues);

--- a/unittests/unit/test_MarkerFitter.cpp
+++ b/unittests/unit/test_MarkerFitter.cpp
@@ -1657,7 +1657,7 @@ std::vector<MarkerInitialization> runEngine(
     fitter.setTriadsToTracking();
   }
   // This is 1.0x the values in the default code
-  fitter.setRegularizeAnatomicalMarkerOffsets(3.0);
+  fitter.setRegularizeAnatomicalMarkerOffsets(10.0);
   // This is 1.0x the default value
   fitter.setRegularizeTrackingMarkerOffsets(0.05);
   // These are 2x the values in the default code

--- a/unittests/unit/test_MarkerFitter.cpp
+++ b/unittests/unit/test_MarkerFitter.cpp
@@ -39,7 +39,7 @@
 
 // #define ALL_TESTS
 
-// #define FUNCTIONAL_TESTS
+#define FUNCTIONAL_TESTS
 
 using namespace dart;
 using namespace biomechanics;
@@ -1657,7 +1657,7 @@ std::vector<MarkerInitialization> runEngine(
     fitter.setTriadsToTracking();
   }
   // This is 1.0x the values in the default code
-  fitter.setRegularizeAnatomicalMarkerOffsets(10.0);
+  fitter.setRegularizeAnatomicalMarkerOffsets(3.0);
   // This is 1.0x the default value
   fitter.setRegularizeTrackingMarkerOffsets(0.05);
   // These are 2x the values in the default code
@@ -1680,8 +1680,9 @@ std::vector<MarkerInitialization> runEngine(
       = Anthropometrics::loadFromFile(
           "dart://sample/osim/ANSUR/ANSUR_metrics.xml");
   std::vector<std::string> cols = anthropometrics->getMetricNames();
-  cols.push_back("Weightlbs");
-  cols.push_back("Heightin");
+  // cols.push_back("Weightlbs");
+  // cols.push_back("Heightin");
+  cols.push_back("weightkg");
   std::shared_ptr<MultivariateGaussian> gauss;
   if (sex == "male")
   {
@@ -1705,13 +1706,17 @@ std::vector<MarkerInitialization> runEngine(
         0.001); // mm -> m
   }
   std::map<std::string, s_t> observedValues;
-  observedValues["Weightlbs"] = massKg * 2.204 * 0.001;
-  observedValues["Heightin"] = heightM * 39.37 * 0.001;
+  std::cout << "Anthro before conditioning:" << std::endl;
+  gauss->debugToStdout();
+  observedValues["weightkg"] = massKg * 0.01;
+  observedValues["stature"] = heightM;
   gauss = gauss->condition(observedValues);
+  std::cout << "Anthro after conditioning:" << std::endl;
+  gauss->debugToStdout();
   anthropometrics->setDistribution(gauss);
-  fitter.setAnthropometricPrior(anthropometrics, 0.1);
 
-  fitter.setExplicitHeightPrior(heightM, 1e3);
+  fitter.setAnthropometricPrior(anthropometrics, 0.1);
+  fitter.setExplicitHeightPrior(heightM, 0.1);
 
   (void)staticPoseMarkers;
   (void)staticPose;
@@ -1802,13 +1807,17 @@ std::vector<MarkerInitialization> runEngine(
   std::cout << "Final kinematic fit report:" << std::endl;
   finalKinematicsReport.printReport(5);
 
-  std::cout << "Final marker locations: " << std::endl;
-  for (auto& pair : results[0].updatedMarkerMap)
-  {
-    Eigen::Vector3s offset = pair.second.second;
-    std::cout << pair.first << ": " << pair.second.first->getName() << ", "
-              << offset(0) << " " << offset(1) << " " << offset(2) << std::endl;
-  }
+  std::cout << "Final anthro: " << std::endl;
+  anthropometrics->debugValues(standard.skeleton);
+
+  // std::cout << "Final marker locations: " << std::endl;
+  // for (auto& pair : results[0].updatedMarkerMap)
+  // {
+  //   Eigen::Vector3s offset = pair.second.second;
+  //   std::cout << pair.first << ": " << pair.second.first->getName() << ", "
+  //             << offset(0) << " " << offset(1) << " " << offset(2) <<
+  //             std::endl;
+  // }
 
   std::cout << "Saving marker error report" << std::endl;
   finalKinematicsReport.saveCSVMarkerErrorReport(
@@ -6026,6 +6035,32 @@ TEST(MarkerFitter, SAM_DATA)
       imuFiles,
       68.45,
       1.68,
+      "male",
+      true);
+}
+#endif
+
+#ifdef ALL_TESTS
+TEST(MarkerFitter, SYNTHETIC_SUBJECT_18)
+{
+  std::vector<std::string> c3dFiles;
+  std::vector<std::string> trcFiles;
+  std::vector<std::string> grfFiles;
+  std::vector<std::string> imuFiles;
+  trcFiles.push_back(
+      "dart://sample/grf/subject18_synthetic/trials/walk2/markers.trc");
+  grfFiles.push_back(
+      "dart://sample/grf/subject18_synthetic/trials/walk2/grf.mot");
+
+  runEngine(
+      "dart://sample/grf/subject18_synthetic/"
+      "unscaled_generic.osim",
+      c3dFiles,
+      trcFiles,
+      grfFiles,
+      imuFiles,
+      64.09,
+      1.775,
       "male",
       true);
 }


### PR DESCRIPTION
This PR fixes several bugs related to the ANSUR data and the anthropometric prior:

1) We were conditioning on columns ("Weightlbs" and "Heightin") that were SELF REPORTED and had the systematic bias you'd expect compared to the real thing. This is now fixed in `test_MarkerFitter`. These changes to the conditioning columns when setting up the anthropometric prior need to be replicated in `engine.py`
2) The measurement points for the anthropometric data were slightly off on the `ANSUR_metrics.xml` file (they'd never been systematically checked before). This has been carefully adjusted, and also needs to be replicated over in AddBiomechanics
3) As a result of all this, I was able to dramatically reduce the weight on the height prior, from 1e3 to 0.1, and still get good height convergence.

Also, this seems to help with pelvis roll quite a bit on the synthetic subject18 data!