### PR TITLE
3 pybinding for Alan Tan

### DIFF
--- a/python/_nimblephysics/biomechanics/MarkerFitter.cpp
+++ b/python/_nimblephysics/biomechanics/MarkerFitter.cpp
@@ -411,6 +411,12 @@ void MarkerFitter(py::module& m)
           ::py::arg("markerTrials"),
           ::py::arg("params"),
           ::py::arg("numSamples") = 50)
+      .def_static(
+          "getMarkerLossGradientWrtJoints",
+          &dart::biomechanics::MarkerFitter::getMarkerLossGradientWrtJoints,
+          ::py::arg("skeleton"),
+          ::py::arg("markers"),
+          ::py::arg("lossGradWrtMarkerError"))
       .def(
           "runKinematicsPipeline",
           &dart::biomechanics::MarkerFitter::runKinematicsPipeline,

--- a/python/_nimblephysics/dynamics/Skeleton.cpp
+++ b/python/_nimblephysics/dynamics/Skeleton.cpp
@@ -1160,6 +1160,14 @@ These are a set of bodies, and offsets in local body space where accs are mounte
 This returns the Jacobian relating changes in the `wrt` quantity to changes in acc readings.
     )docs")
       .def(
+          "getBodyLocalVelocities",
+          &dart::dynamics::Skeleton::getBodyLocalVelocities
+          )
+      .def(
+          "getBodyLocalAccelerations",
+          &dart::dynamics::Skeleton::getBodyLocalAccelerations
+          )
+      .def(
           "setVelocityUpperLimits",
           +[](dart::dynamics::Skeleton* self, Eigen::VectorXs limits) -> void {
             self->setVelocityUpperLimits(limits);


### PR DESCRIPTION
Added 3 pybindings:
1. getMarkerLossGradientWrtJoints from MarkerFitter
2. getBodyLocalVelocities from Skeleton
3. getBodyLocalAccelerations from Skeleton

Tested on my own machine with no errors.