### PR TITLE
Throw useful exceptions when TRC formatting is invalid

### DIFF
--- a/dart/biomechanics/OpenSimParser.cpp
+++ b/dart/biomechanics/OpenSimParser.cpp
@@ -3077,6 +3077,15 @@ OpenSimTRC OpenSimParser::loadTRC(
             if (!markerSwapSpace.hasNaN()
                 && (markerSwapSpace != Eigen::Vector3s::Zero()))
             {
+              if (markerNames.empty()) {
+                NIMBLE_THROW("No marker names found in TRC file. Please check "
+                             "that the file is formatted correctly.");
+              }
+              if (markerNumber >= (int)markerNames.size()) {
+                NIMBLE_THROW("Marker number exceeds number of marker names in "
+                             "TRC file. Please check that the file is formatted "
+                             "correctly.");
+              }
               markerPositions[markerNames[markerNumber]]
                   = Eigen::Vector3s(markerSwapSpace);
             }


### PR DESCRIPTION
This PR add some useful checks that the TRC loaded in was correctly formatted. We check that marker names from the header were detected, and that the current marker being parsed doesn't have an index larger that the current list of marker names.
