### PR TITLE
Adding `SubjectOnDiskTrialPass::computeKinematicValues`

### DIFF
--- a/dart/biomechanics/SubjectOnDisk.hpp
+++ b/dart/biomechanics/SubjectOnDisk.hpp
@@ -185,6 +185,18 @@ public:
       Eigen::MatrixXs explicitAccs = Eigen::MatrixXs::Zero(0, 0),
       s_t forcePlateZeroThresholdNewtons = 3.0);
 
+  // This is for allowing the user to set all the kinematic values of a pass at
+  // once. All dynamics values are set to zero.
+  void computeKinematicValues(
+      std::shared_ptr<dynamics::Skeleton> skel,
+      s_t timestep,
+      Eigen::MatrixXs poses,
+      // How much history to use for the root position and orientation
+      int rootHistoryLen = 5,
+      int rootHistoryStride = 1,
+      Eigen::MatrixXs explicitVels = Eigen::MatrixXs::Zero(0, 0),
+      Eigen::MatrixXs explicitAccs = Eigen::MatrixXs::Zero(0, 0));
+
   // Manual setters (and getters) that compete with computeValues()
   void setLinearResidual(std::vector<s_t> linearResidual);
   std::vector<s_t> getLinearResidual();

--- a/dart/biomechanics/SubjectOnDisk.hpp
+++ b/dart/biomechanics/SubjectOnDisk.hpp
@@ -169,6 +169,18 @@ public:
       int rootHistoryLen = 5,
       int rootHistoryStride = 1);
 
+  // This is for allowing the user to set all the kinematic values of a pass at
+  // once. All dynamics values are set to zero.
+  void computeKinematicValues(
+      std::shared_ptr<dynamics::Skeleton> skel,
+      s_t timestep,
+      Eigen::MatrixXs poses,
+      // How much history to use for the root position and orientation
+      int rootHistoryLen = 5,
+      int rootHistoryStride = 1,
+      Eigen::MatrixXs explicitVels = Eigen::MatrixXs::Zero(0, 0),
+      Eigen::MatrixXs explicitAccs = Eigen::MatrixXs::Zero(0, 0));
+
   // This is for allowing the user to set all the values of a pass at once,
   // without having to manually compute them in Python, which turns out to be
   // slow and difficult to test.
@@ -184,18 +196,6 @@ public:
       Eigen::MatrixXs explicitVels = Eigen::MatrixXs::Zero(0, 0),
       Eigen::MatrixXs explicitAccs = Eigen::MatrixXs::Zero(0, 0),
       s_t forcePlateZeroThresholdNewtons = 3.0);
-
-  // This is for allowing the user to set all the kinematic values of a pass at
-  // once. All dynamics values are set to zero.
-  void computeKinematicValues(
-      std::shared_ptr<dynamics::Skeleton> skel,
-      s_t timestep,
-      Eigen::MatrixXs poses,
-      // How much history to use for the root position and orientation
-      int rootHistoryLen = 5,
-      int rootHistoryStride = 1,
-      Eigen::MatrixXs explicitVels = Eigen::MatrixXs::Zero(0, 0),
-      Eigen::MatrixXs explicitAccs = Eigen::MatrixXs::Zero(0, 0));
 
   // Manual setters (and getters) that compete with computeValues()
   void setLinearResidual(std::vector<s_t> linearResidual);

--- a/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
+++ b/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
@@ -599,6 +599,17 @@ Note that these are specified in the local body frame, acting on the body at its
                 ::py::arg("explicitAccs") = Eigen::MatrixXs::Zero(0, 0),
                 ::py::arg("forcePlateZeroThresholdNewtons") = 3.0)
             .def(
+                "computeKinematicValues",
+                &dart::biomechanics::SubjectOnDiskTrialPass::
+                    computeKinematicValues,
+                ::py::arg("skel"),
+                ::py::arg("timestep"),
+                ::py::arg("poses"),
+                ::py::arg("rootHistoryLen") = 5,
+                ::py::arg("rootHistoryStride") = 1,
+                ::py::arg("explicitVels") = Eigen::MatrixXs::Zero(0, 0),
+                ::py::arg("explicitAccs") = Eigen::MatrixXs::Zero(0, 0))
+            .def(
                 "setLinearResidual",
                 &dart::biomechanics::SubjectOnDiskTrialPass::setLinearResidual,
                 ::py::arg("linearResidual"))

--- a/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
+++ b/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
@@ -585,6 +585,17 @@ Note that these are specified in the local body frame, acting on the body at its
                 ::py::arg("rootHistoryLen") = 5,
                 ::py::arg("rootHistoryStride") = 1)
             .def(
+                "computeKinematicValues",
+                &dart::biomechanics::SubjectOnDiskTrialPass::
+                    computeKinematicValues,
+                ::py::arg("skel"),
+                ::py::arg("timestep"),
+                ::py::arg("poses"),
+                ::py::arg("rootHistoryLen") = 5,
+                ::py::arg("rootHistoryStride") = 1,
+                ::py::arg("explicitVels") = Eigen::MatrixXs::Zero(0, 0),
+                ::py::arg("explicitAccs") = Eigen::MatrixXs::Zero(0, 0))
+            .def(
                 "computeValuesFromForcePlates",
                 &dart::biomechanics::SubjectOnDiskTrialPass::
                     computeValuesFromForcePlates,
@@ -598,17 +609,6 @@ Note that these are specified in the local body frame, acting on the body at its
                 ::py::arg("explicitVels") = Eigen::MatrixXs::Zero(0, 0),
                 ::py::arg("explicitAccs") = Eigen::MatrixXs::Zero(0, 0),
                 ::py::arg("forcePlateZeroThresholdNewtons") = 3.0)
-            .def(
-                "computeKinematicValues",
-                &dart::biomechanics::SubjectOnDiskTrialPass::
-                    computeKinematicValues,
-                ::py::arg("skel"),
-                ::py::arg("timestep"),
-                ::py::arg("poses"),
-                ::py::arg("rootHistoryLen") = 5,
-                ::py::arg("rootHistoryStride") = 1,
-                ::py::arg("explicitVels") = Eigen::MatrixXs::Zero(0, 0),
-                ::py::arg("explicitAccs") = Eigen::MatrixXs::Zero(0, 0))
             .def(
                 "setLinearResidual",
                 &dart::biomechanics::SubjectOnDiskTrialPass::setLinearResidual,


### PR DESCRIPTION
Fixes https://github.com/keenon/AddBiomechanics/issues/227.

This PR accomplishes two things:

-  Adds `SubjectOnDiskTrialPass::computeKinematicValues` for computing all kinematic values in a trial while setting all dynamics values to zero.
-  `SubjectOnDiskTrialPass::computeValuesFromForcePlates` calls `SubjectOnDiskTrialPass::computeKinematicValues` if incorrect foot body name is provided.
