### PR TITLE
Upgrading "Build and Publish Wheels" CI workflow to use macos12

### DIFF
--- a/.github/workflows/build_x86_mac_wheels.yml
+++ b/.github/workflows/build_x86_mac_wheels.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-mac:
     name: Mac OSX Python ${{ matrix.python-version }} - Build Wheels
-    runs-on: macos-13
+    runs-on: macos-12
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/build_x86_mac_wheels.yml
+++ b/.github/workflows/build_x86_mac_wheels.yml
@@ -4,10 +4,13 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+  pull_request:
+    branches:
+      - "**"
 jobs:
   build-mac:
     name: Mac OSX Python ${{ matrix.python-version }} - Build Wheels
-    runs-on: macos-11
+    runs-on: macos-13
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
@@ -64,32 +67,32 @@ jobs:
         with:
           name: nimblephysics-${{ env.VERSION }}-${{ matrix.PYTHON_VERSION_CODE }}-macosx_10_9_x86_64.whl
           path: wheelhouse/nimblephysics-${{ env.VERSION }}-${{ matrix.PYTHON_VERSION_CODE }}-macosx_10_9_x86_64.whl
-  publish:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    needs: [build-mac]
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: wheelhouse
-      - name: Display structure of downloaded files before flattening
-        run: ls -R
-        working-directory: wheelhouse
-      - name: Flatten files
-        run: |
-          mkdir wheelhouse2
-          find wheelhouse -type f -exec mv {} wheelhouse2 \;
-          rm -rf wheelhouse
-          mv wheelhouse2 wheelhouse
-      - name: Display structure of downloaded files after flattening
-        run: ls -R
-        working-directory: wheelhouse
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.8
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: wheelhouse/
-          skip_existing: true
-          verbose: true
+  # publish:
+  #   name: Publish to PyPI
+  #   runs-on: ubuntu-latest
+  #   needs: [build-mac]
+  #   steps:
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: wheelhouse
+  #     - name: Display structure of downloaded files before flattening
+  #       run: ls -R
+  #       working-directory: wheelhouse
+  #     - name: Flatten files
+  #       run: |
+  #         mkdir wheelhouse2
+  #         find wheelhouse -type f -exec mv {} wheelhouse2 \;
+  #         rm -rf wheelhouse
+  #         mv wheelhouse2 wheelhouse
+  #     - name: Display structure of downloaded files after flattening
+  #       run: ls -R
+  #       working-directory: wheelhouse
+  #     - name: Publish package to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1.8
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.PYPI_API_TOKEN }}
+  #         packages_dir: wheelhouse/
+  #         skip_existing: true
+  #         verbose: true

--- a/.github/workflows/build_x86_mac_wheels.yml
+++ b/.github/workflows/build_x86_mac_wheels.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   release:
     types: [published]
-  pull_request:
-    branches:
-      - "**"
 jobs:
   build-mac:
     name: Mac OSX Python ${{ matrix.python-version }} - Build Wheels
@@ -67,32 +64,32 @@ jobs:
         with:
           name: nimblephysics-${{ env.VERSION }}-${{ matrix.PYTHON_VERSION_CODE }}-macosx_10_9_x86_64.whl
           path: wheelhouse/nimblephysics-${{ env.VERSION }}-${{ matrix.PYTHON_VERSION_CODE }}-macosx_10_9_x86_64.whl
-  # publish:
-  #   name: Publish to PyPI
-  #   runs-on: ubuntu-latest
-  #   needs: [build-mac]
-  #   steps:
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: wheelhouse
-  #     - name: Display structure of downloaded files before flattening
-  #       run: ls -R
-  #       working-directory: wheelhouse
-  #     - name: Flatten files
-  #       run: |
-  #         mkdir wheelhouse2
-  #         find wheelhouse -type f -exec mv {} wheelhouse2 \;
-  #         rm -rf wheelhouse
-  #         mv wheelhouse2 wheelhouse
-  #     - name: Display structure of downloaded files after flattening
-  #       run: ls -R
-  #       working-directory: wheelhouse
-  #     - name: Publish package to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1.8
-  #       with:
-  #         user: __token__
-  #         password: ${{ secrets.PYPI_API_TOKEN }}
-  #         packages_dir: wheelhouse/
-  #         skip_existing: true
-  #         verbose: true
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [build-mac]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: wheelhouse
+      - name: Display structure of downloaded files before flattening
+        run: ls -R
+        working-directory: wheelhouse
+      - name: Flatten files
+        run: |
+          mkdir wheelhouse2
+          find wheelhouse -type f -exec mv {} wheelhouse2 \;
+          rm -rf wheelhouse
+          mv wheelhouse2 wheelhouse
+      - name: Display structure of downloaded files after flattening
+        run: ls -R
+        working-directory: wheelhouse
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.8
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: wheelhouse/
+          skip_existing: true
+          verbose: true

--- a/ci/mac/install_dependencies.sh
+++ b/ci/mac/install_dependencies.sh
@@ -13,7 +13,6 @@ brew reinstall gcc
 export FC=$(which gfortran)
 echo "FC=$FC"
 
-# export MACOSX_DEPLOYMENT_TARGET="11.0"
 export MACOSX_DEPLOYMENT_TARGET="12.0"
 export CMAKE_FLAGS="-DCMAKE_OSX_ARCHITECTURES=x86_64"
 

--- a/ci/mac/install_dependencies.sh
+++ b/ci/mac/install_dependencies.sh
@@ -14,7 +14,7 @@ export FC=$(which gfortran)
 echo "FC=$FC"
 
 # export MACOSX_DEPLOYMENT_TARGET="11.0"
-export MACOSX_DEPLOYMENT_TARGET="10.9"
+export MACOSX_DEPLOYMENT_TARGET="12.0"
 export CMAKE_FLAGS="-DCMAKE_OSX_ARCHITECTURES=x86_64"
 
 export PYTHON3=$(which python3)


### PR DESCRIPTION
This PR upgrades the "Build and Publish Wheels" CI workflow to use the GitHub MacOS 12 runner, since MacOS 11 is deprecated. The current runner was timing out a lot since builds were taking forever, so this is also a good QoL update.

@keenon, is any reason you think upgrading to MacOS 12 would affect the Mac wheels? They build on GitHub Actions just fine (see the second commit below), but I haven't tested them manually.
