### PR TITLE
Adding some SubjectOnDisk fields and a binding for unwrapEulerAngles

### DIFF
--- a/dart/biomechanics/SubjectOnDisk.cpp
+++ b/dart/biomechanics/SubjectOnDisk.cpp
@@ -181,6 +181,84 @@ MissingGRFReason missingGRFReasonFromProto(proto::MissingGRFReason reason)
   return notMissingGRF;
 }
 
+BasicTrialType basicTrialTypeFromProto(proto::BasicTrialType type)
+{
+  switch (type)
+  {
+    case proto::BasicTrialType::treadmill:
+      return treadmill;
+    case proto::BasicTrialType::overground:
+      return overground;
+    case proto::BasicTrialType::staticTrial:
+      return staticTrial;
+    case proto::BasicTrialType::other:
+      return other;
+    case proto::BasicTrialType_INT_MIN_SENTINEL_DO_NOT_USE_:
+      return other;
+      break;
+    case proto::BasicTrialType_INT_MAX_SENTINEL_DO_NOT_USE_:
+      return other;
+      break;
+  }
+  return other;
+}
+
+proto::BasicTrialType basicTrialTypeToProto(BasicTrialType type)
+{
+  switch (type)
+  {
+    case treadmill:
+      return proto::BasicTrialType::treadmill;
+    case overground:
+      return proto::BasicTrialType::overground;
+    case staticTrial:
+      return proto::BasicTrialType::staticTrial;
+    case other:
+      return proto::BasicTrialType::other;
+  }
+  return proto::BasicTrialType::other;
+}
+
+DetectedTrialFeature detectedTrialFeatureFromProto(
+    proto::DetectedTrialFeature feature)
+{
+  switch (feature)
+  {
+    case proto::DetectedTrialFeature::walking:
+      return walking;
+    case proto::DetectedTrialFeature::running:
+      return running;
+    case proto::DetectedTrialFeature::unevenTerrain:
+      return unevenTerrain;
+    case proto::DetectedTrialFeature::flatTerrain:
+      return flatTerrain;
+    case proto::DetectedTrialFeature_INT_MIN_SENTINEL_DO_NOT_USE_:
+      return walking;
+      break;
+    case proto::DetectedTrialFeature_INT_MAX_SENTINEL_DO_NOT_USE_:
+      return walking;
+      break;
+  }
+  return walking;
+}
+
+proto::DetectedTrialFeature detectedTrialFeatureToProto(
+    DetectedTrialFeature feature)
+{
+  switch (feature)
+  {
+    case walking:
+      return proto::DetectedTrialFeature::walking;
+    case running:
+      return proto::DetectedTrialFeature::running;
+    case unevenTerrain:
+      return proto::DetectedTrialFeature::unevenTerrain;
+    case flatTerrain:
+      return proto::DetectedTrialFeature::flatTerrain;
+  }
+  return proto::DetectedTrialFeature::walking;
+}
+
 SubjectOnDisk::SubjectOnDisk(const std::string& path)
   : mPath(path), mLoadedAllFrames(false)
 {
@@ -3193,6 +3271,17 @@ void SubjectOnDiskTrial::setMissingGRFReason(
   mMissingGRFReason = missingGRFReason;
 }
 
+std::vector<bool> SubjectOnDiskTrial::getHasManualGRFAnnotation()
+{
+  return mHasManualGRFAnnotation;
+}
+
+void SubjectOnDiskTrial::setHasManualGRFAnnotation(
+    std::vector<bool> hasManualGRFAnnotation)
+{
+  mHasManualGRFAnnotation = hasManualGRFAnnotation;
+}
+
 void SubjectOnDiskTrial::setCustomValues(
     std::vector<Eigen::MatrixXs> customValues)
 {
@@ -3250,6 +3339,27 @@ std::vector<ForcePlate> SubjectOnDiskTrial::getForcePlates()
   return mForcePlates;
 }
 
+void SubjectOnDiskTrial::setBasicTrialType(BasicTrialType type)
+{
+  mBasicTrialType = type;
+}
+
+BasicTrialType SubjectOnDiskTrial::getBasicTrialType()
+{
+  return mBasicTrialType;
+}
+
+void SubjectOnDiskTrial::setDetectedTrialFeatures(
+    std::vector<DetectedTrialFeature> features)
+{
+  mDetectedTrialFeatures = features;
+}
+
+std::vector<DetectedTrialFeature> SubjectOnDiskTrial::getDetectedTrialFeatures()
+{
+  return mDetectedTrialFeatures;
+}
+
 std::shared_ptr<SubjectOnDiskTrialPass> SubjectOnDiskTrial::addPass()
 {
   mTrialPasses.push_back(std::make_shared<SubjectOnDiskTrialPass>());
@@ -3304,6 +3414,19 @@ void SubjectOnDiskTrial::read(const proto::SubjectOnDiskTrialHeader& proto)
   {
     mMissingGRFReason.push_back(
         missingGRFReasonFromProto(proto.missing_grf_reason(i)));
+  }
+  mHasManualGRFAnnotation.clear();
+  for (int i = 0; i < proto.has_manual_grf_annotation_size(); i++)
+  {
+    mHasManualGRFAnnotation.push_back(proto.has_manual_grf_annotation(i));
+  }
+
+  mBasicTrialType = basicTrialTypeFromProto(proto.trial_type());
+  mDetectedTrialFeatures.clear();
+  for (int i = 0; i < proto.detected_trial_feature_size(); i++)
+  {
+    mDetectedTrialFeatures.push_back(
+        detectedTrialFeatureFromProto(proto.detected_trial_feature(i)));
   }
 
   // ///////////////////////////////////////////////////////////////////////////
@@ -3377,6 +3500,16 @@ void SubjectOnDiskTrial::write(proto::SubjectOnDiskTrialHeader* proto)
   {
     proto->add_missing_grf_reason(
         missingGRFReasonToProto(mMissingGRFReason[i]));
+  }
+  for (int i = 0; i < mHasManualGRFAnnotation.size(); i++)
+  {
+    proto->add_has_manual_grf_annotation(mHasManualGRFAnnotation[i]);
+  }
+  proto->set_trial_type(basicTrialTypeToProto(mBasicTrialType));
+  for (int i = 0; i < mDetectedTrialFeatures.size(); i++)
+  {
+    proto->add_detected_trial_feature(
+        detectedTrialFeatureToProto(mDetectedTrialFeatures[i]));
   }
 
   // ///////////////////////////////////////////////////////////////////////////

--- a/dart/biomechanics/SubjectOnDisk.cpp
+++ b/dart/biomechanics/SubjectOnDisk.cpp
@@ -219,6 +219,40 @@ proto::BasicTrialType basicTrialTypeToProto(BasicTrialType type)
   return proto::BasicTrialType::other;
 }
 
+DataQuality dataQualityFromProto(proto::DataQuality quality)
+{
+  switch (quality)
+  {
+    case proto::DataQuality::pilotData:
+      return pilotData;
+    case proto::DataQuality::experimentalData:
+      return experimentalData;
+    case proto::DataQuality::internetData:
+      return internetData;
+    case proto::DataQuality_INT_MIN_SENTINEL_DO_NOT_USE_:
+      return internetData;
+      break;
+    case proto::DataQuality_INT_MAX_SENTINEL_DO_NOT_USE_:
+      return internetData;
+      break;
+  }
+  return internetData;
+}
+
+proto::DataQuality dataQualityToProto(DataQuality quality)
+{
+  switch (quality)
+  {
+    case pilotData:
+      return proto::DataQuality::pilotData;
+    case experimentalData:
+      return proto::DataQuality::experimentalData;
+    case internetData:
+      return proto::DataQuality::internetData;
+  }
+  return proto::DataQuality::pilotData;
+}
+
 DetectedTrialFeature detectedTrialFeatureFromProto(
     proto::DetectedTrialFeature feature)
 {
@@ -1566,6 +1600,12 @@ std::vector<MissingGRFReason> SubjectOnDisk::getMissingGRF(int trial)
     return std::vector<MissingGRFReason>();
   }
   return mHeader->mTrials[trial]->mMissingGRFReason;
+}
+
+/// This returns the user supplied enum of type 'DataQuality'
+DataQuality SubjectOnDisk::getQuality()
+{
+  return mHeader->getQuality();
 }
 
 int SubjectOnDisk::getNumProcessingPasses()
@@ -3680,6 +3720,17 @@ SubjectOnDiskHeader& SubjectOnDiskHeader::setNotes(const std::string& notes)
   return *this;
 }
 
+SubjectOnDiskHeader& SubjectOnDiskHeader::setQuality(DataQuality quality)
+{
+  mDataQuality = quality;
+  return *this;
+}
+
+DataQuality SubjectOnDiskHeader::getQuality()
+{
+  return mDataQuality;
+}
+
 std::shared_ptr<SubjectOnDiskPassHeader>
 SubjectOnDiskHeader::addProcessingPass()
 {
@@ -3915,6 +3966,7 @@ void SubjectOnDiskHeader::write(dart::proto::SubjectOnDiskHeader* header)
   {
     header->add_exo_dof_index(index);
   }
+  header->set_data_quality(dataQualityToProto(mDataQuality));
 
   if (!header->IsInitialized())
   {
@@ -4059,6 +4111,8 @@ void SubjectOnDiskHeader::read(const dart::proto::SubjectOnDiskHeader& proto)
   {
     mExoDofIndices.push_back(proto.exo_dof_index(i));
   }
+
+  mDataQuality = dataQualityFromProto(proto.data_quality());
 }
 
 void SubjectOnDiskHeader::writeSensorsFrame(

--- a/dart/biomechanics/SubjectOnDisk.hpp
+++ b/dart/biomechanics/SubjectOnDisk.hpp
@@ -463,6 +463,8 @@ public:
   SubjectOnDiskHeader& setSubjectTags(std::vector<std::string> subjectTags);
   SubjectOnDiskHeader& setHref(const std::string& sourceHref);
   SubjectOnDiskHeader& setNotes(const std::string& notes);
+  SubjectOnDiskHeader& setQuality(DataQuality quality);
+  DataQuality getQuality();
   std::shared_ptr<SubjectOnDiskPassHeader> addProcessingPass();
   std::vector<std::shared_ptr<SubjectOnDiskPassHeader>> getProcessingPasses();
   std::shared_ptr<SubjectOnDiskTrial> addTrial();
@@ -521,6 +523,9 @@ protected:
   int mEmgDim;
   // This is exoskeleton data
   std::vector<int> mExoDofIndices;
+
+  // This is the user supplied quality of the data
+  DataQuality mDataQuality;
 
   friend class SubjectOnDisk;
   friend struct Frame;
@@ -636,6 +641,9 @@ public:
   /// This returns the vector of enums of type 'MissingGRFReason', which can
   /// include `notMissingGRF`.
   std::vector<MissingGRFReason> getMissingGRF(int trial);
+
+  /// This returns the user supplied enum of type 'DataQuality'
+  DataQuality getQuality();
 
   int getNumProcessingPasses();
 

--- a/dart/biomechanics/SubjectOnDisk.hpp
+++ b/dart/biomechanics/SubjectOnDisk.hpp
@@ -347,6 +347,8 @@ public:
   void setOriginalTrialEndTime(s_t endTime);
   std::vector<MissingGRFReason> getMissingGRFReason();
   void setMissingGRFReason(std::vector<MissingGRFReason> missingGRFReason);
+  std::vector<bool> getHasManualGRFAnnotation();
+  void setHasManualGRFAnnotation(std::vector<bool> hasManualGRFAnnotation);
   void setCustomValues(std::vector<Eigen::MatrixXs> customValues);
   void setMarkerNamesGuessed(bool markersGuessed);
   std::vector<std::map<std::string, Eigen::Vector3s>> getMarkerObservations();
@@ -361,6 +363,10 @@ public:
   void setExoTorques(std::map<int, Eigen::VectorXs> exoTorques);
   void setForcePlates(std::vector<ForcePlate> forcePlates);
   std::vector<ForcePlate> getForcePlates();
+  void setBasicTrialType(BasicTrialType type);
+  BasicTrialType getBasicTrialType();
+  void setDetectedTrialFeatures(std::vector<DetectedTrialFeature> features);
+  std::vector<DetectedTrialFeature> getDetectedTrialFeatures();
   std::shared_ptr<SubjectOnDiskTrialPass> addPass();
   std::vector<std::shared_ptr<SubjectOnDiskTrialPass>> getPasses();
   void read(const proto::SubjectOnDiskTrialHeader& proto);
@@ -373,6 +379,7 @@ protected:
   std::vector<std::string> mTrialTags;
   std::vector<std::shared_ptr<SubjectOnDiskTrialPass>> mTrialPasses;
   std::vector<MissingGRFReason> mMissingGRFReason;
+  std::vector<bool> mHasManualGRFAnnotation;
   // This is true if we guessed the marker names, and false if we got them from
   // the uploaded user's file, which implies that they got them from human
   // observations.
@@ -384,6 +391,9 @@ protected:
   int mOriginalTrialEndFrame;
   s_t mOriginalTrialStartTime;
   s_t mOriginalTrialEndTime;
+
+  BasicTrialType mBasicTrialType;
+  std::vector<DetectedTrialFeature> mDetectedTrialFeatures;
 
   ///////////////////////////////////////////////////////////////////////////
   // Recovered proto summaries, for incremental loading of Frames

--- a/dart/biomechanics/enums.hpp
+++ b/dart/biomechanics/enums.hpp
@@ -29,6 +29,22 @@ enum MissingGRFReason
   extendedToNearestPeakForce
 };
 
+enum BasicTrialType
+{
+  treadmill,
+  overground,
+  staticTrial,
+  other
+};
+
+enum DetectedTrialFeature
+{
+  walking,
+  running,
+  unevenTerrain,
+  flatTerrain
+};
+
 enum MissingGRFStatus
 {
   no = 0,      // no will cast to `false`

--- a/dart/biomechanics/enums.hpp
+++ b/dart/biomechanics/enums.hpp
@@ -45,6 +45,13 @@ enum DetectedTrialFeature
   flatTerrain
 };
 
+enum DataQuality
+{
+  pilotData,
+  experimentalData,
+  internetData
+};
+
 enum MissingGRFStatus
 {
   no = 0,      // no will cast to `false`

--- a/dart/proto/SubjectOnDisk.proto
+++ b/dart/proto/SubjectOnDisk.proto
@@ -44,6 +44,12 @@ enum DetectedTrialFeature {
   flatTerrain = 3;
 }
 
+enum DataQuality {
+  pilotData = 0;
+  experimentalData = 1;
+  internetData = 2;
+}
+
 // Many of the ML tasks we want to support from SubjectOnDisk data include 
 // effectively predicting the results of a downstream processing task from 
 // an upstream processing task. Trivially, that's predicting physics from
@@ -166,6 +172,8 @@ message SubjectOnDiskHeader {
   repeated int32 exo_dof_index = 22;
   // Details about the subject tags provided on the AddBiomechanics platform
   repeated string subject_tag = 23;
+  // This is what the user has tagged this subject as, in terms of data quality
+  DataQuality data_quality = 25;
 }
 
 message SubjectOnDiskProcessingPassFrame {

--- a/dart/proto/SubjectOnDisk.proto
+++ b/dart/proto/SubjectOnDisk.proto
@@ -30,6 +30,20 @@ enum ProcessingPassType {
   accMinimizingFilter = 3;
 };
 
+enum BasicTrialType {
+  treadmill = 0;
+  overground = 1;
+  staticTrial = 2;
+  other = 3;
+};
+
+enum DetectedTrialFeature {
+  walking = 0;
+  running = 1;
+  unevenTerrain = 2;
+  flatTerrain = 3;
+}
+
 // Many of the ML tasks we want to support from SubjectOnDisk data include 
 // effectively predicting the results of a downstream processing task from 
 // an upstream processing task. Trivially, that's predicting physics from
@@ -79,6 +93,7 @@ message SubjectOnDiskTrialHeader {
   // memory, but we really want to know this information when randomly picking
   // frames from the subject to sample.
   repeated MissingGRFReason missing_GRF_reason = 2;
+  repeated bool has_manual_GRF_annotation = 16;
   // This is how many frames are in this trial
   int32 trial_length = 3;
   // This is the timestep used in this trial (assumed constant throughout the trial)
@@ -102,6 +117,10 @@ message SubjectOnDiskTrialHeader {
   int32 original_trial_end_frame = 13;
   float original_trial_start_time = 14;
   float original_trial_end_time = 15;
+  // This is the type of trial we're dealing with
+  BasicTrialType trial_type = 17;
+  // This is the detected features of this trial
+  repeated DetectedTrialFeature detected_trial_feature = 18;
 }
 
 message SubjectOnDiskPass {

--- a/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
+++ b/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
@@ -50,6 +50,51 @@ void SubjectOnDisk(py::module& m)
                 "This is the pass where we apply an acceleration minimizing "
                 "filter to the kinematics and dynamics.");
 
+  auto basicTrialType
+      = ::py::enum_<dart::biomechanics::BasicTrialType>(m, "BasicTrialType")
+            .value(
+                "TREADMILL",
+                dart::biomechanics::BasicTrialType::treadmill,
+                "This is a trial where the subject is walking or "
+                "running on a treadmill.")
+            .value(
+                "OVERGROUND",
+                dart::biomechanics::BasicTrialType::overground,
+                "This is a trial where the subject is walking or "
+                "running overground.")
+            .value(
+                "STATIC_TRIAL",
+                dart::biomechanics::BasicTrialType::staticTrial,
+                "This is a trial where the subject is standing "
+                "still.")
+            .value(
+                "OTHER",
+                dart::biomechanics::BasicTrialType::other,
+                "This is a trial that doesn't fit into any of the "
+                "other categories.");
+
+  auto detectedTrialFeature
+      = ::py::enum_<dart::biomechanics::DetectedTrialFeature>(
+            m, "DetectedTrialFeature")
+            .value(
+                "WALKING",
+                dart::biomechanics::DetectedTrialFeature::walking,
+                "This is a trial where the subject is walking.")
+            .value(
+                "RUNNING",
+                dart::biomechanics::DetectedTrialFeature::running,
+                "This is a trial where the subject is running.")
+            .value(
+                "UNEVEN_TERRAIN",
+                dart::biomechanics::DetectedTrialFeature::unevenTerrain,
+                "This is a trial where the subject is walking or "
+                "running on uneven terrain.")
+            .value(
+                "FLAT_TERRAIN",
+                dart::biomechanics::DetectedTrialFeature::flatTerrain,
+                "This is a trial where the subject is walking or "
+                "running on flat terrain.");
+
   auto framePass
       = ::py::class_<
             dart::biomechanics::FramePass,
@@ -892,6 +937,15 @@ Note that these are specified in the local body frame, acting on the body at its
                 "getMissingGRFReason",
                 &dart::biomechanics::SubjectOnDiskTrial::getMissingGRFReason)
             .def(
+                "setHasManualGRFAnnotation",
+                &dart::biomechanics::SubjectOnDiskTrial::
+                    setHasManualGRFAnnotation,
+                ::py::arg("hasManualGRFAnnotation"))
+            .def(
+                "getHasManualGRFAnnotation",
+                &dart::biomechanics::SubjectOnDiskTrial::
+                    getHasManualGRFAnnotation)
+            .def(
                 "setCustomValues",
                 &dart::biomechanics::SubjectOnDiskTrial::setCustomValues,
                 ::py::arg("customValues"))
@@ -929,6 +983,22 @@ Note that these are specified in the local body frame, acting on the body at its
             .def(
                 "getForcePlates",
                 &dart::biomechanics::SubjectOnDiskTrial::getForcePlates)
+            .def(
+                "setBasicTrialType",
+                &dart::biomechanics::SubjectOnDiskTrial::setBasicTrialType,
+                ::py::arg("type"))
+            .def(
+                "getBasicTrialType",
+                &dart::biomechanics::SubjectOnDiskTrial::getBasicTrialType)
+            .def(
+                "setDetectedTrialFeatures",
+                &dart::biomechanics::SubjectOnDiskTrial::
+                    setDetectedTrialFeatures,
+                ::py::arg("features"))
+            .def(
+                "getDetectedTrialFeatures",
+                &dart::biomechanics::SubjectOnDiskTrial::
+                    getDetectedTrialFeatures)
             .def(
                 "addPass",
                 &dart::biomechanics::SubjectOnDiskTrial::addPass,

--- a/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
+++ b/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
@@ -73,6 +73,21 @@ void SubjectOnDisk(py::module& m)
                 "This is a trial that doesn't fit into any of the "
                 "other categories.");
 
+  auto dataQuality
+      = ::py::enum_<dart::biomechanics::DataQuality>(m, "DataQuality")
+            .value(
+                "PILOT_DATA",
+                dart::biomechanics::DataQuality::pilotData,
+                "This is data that was collected as part of a pilot study.")
+            .value(
+                "EXPERIMENTAL_DATA",
+                dart::biomechanics::DataQuality::experimentalData,
+                "This is data that was collected as part of an experiment.")
+            .value(
+                "INTERNET_DATA",
+                dart::biomechanics::DataQuality::internetData,
+                "This is data that was collected from the internet.");
+
   auto detectedTrialFeature
       = ::py::enum_<dart::biomechanics::DetectedTrialFeature>(
             m, "DetectedTrialFeature")
@@ -1090,6 +1105,13 @@ Note that these are specified in the local body frame, acting on the body at its
                 &dart::biomechanics::SubjectOnDiskHeader::setNotes,
                 ::py::arg("notes"))
             .def(
+                "setQuality",
+                &dart::biomechanics::SubjectOnDiskHeader::setQuality,
+                ::py::arg("quality"))
+            .def(
+                "getQuality",
+                &dart::biomechanics::SubjectOnDiskHeader::getQuality)
+            .def(
                 "addProcessingPass",
                 &dart::biomechanics::SubjectOnDiskHeader::addProcessingPass)
             .def(
@@ -1323,6 +1345,11 @@ Note that these are specified in the local body frame, acting on the body at its
             This method is provided to give a cheaper way to filter out frames we want to ignore for training, without having to call
             the more expensive :code:`loadFrames()` and examine frames individually.
           )doc")
+            .def(
+                "getQuality",
+                &dart::biomechanics::SubjectOnDisk::getQuality,
+                "This returns the user-supplied quality of the data in this "
+                "subject")
             //   int getNumProcessingPasses();
             .def(
                 "getNumProcessingPasses",

--- a/python/_nimblephysics/dynamics/EulerJoint.cpp
+++ b/python/_nimblephysics/dynamics/EulerJoint.cpp
@@ -44,17 +44,17 @@ namespace python {
 
 void EulerJoint(py::module& m)
 {
-  ::py::enum_<dart::dynamics::EulerJoint::AxisOrder>(m, "AxisOrder")
-      .value("XYZ", dart::dynamics::EulerJoint::AxisOrder::XYZ)
-      .value("XZY", dart::dynamics::EulerJoint::AxisOrder::XZY)
-      .value("ZYX", dart::dynamics::EulerJoint::AxisOrder::ZYX)
-      .value("ZXY", dart::dynamics::EulerJoint::AxisOrder::ZXY);
+  ::py::enum_<dart::dynamics::detail::AxisOrder>(m, "AxisOrder")
+      .value("XYZ", dart::dynamics::detail::AxisOrder::XYZ)
+      .value("XZY", dart::dynamics::detail::AxisOrder::XZY)
+      .value("ZYX", dart::dynamics::detail::AxisOrder::ZYX)
+      .value("ZXY", dart::dynamics::detail::AxisOrder::ZXY);
 
   ::py::class_<dart::dynamics::EulerJoint::UniqueProperties>(
       m, "EulerJointUniqueProperties")
       .def(::py::init<>())
       .def(
-          ::py::init<dart::dynamics::EulerJoint::AxisOrder>(),
+          ::py::init<dart::dynamics::detail::AxisOrder>(),
           ::py::arg("axisOrder"));
 
   ::py::class_<
@@ -162,21 +162,21 @@ void EulerJoint(py::module& m)
       .def(
           "setAxisOrder",
           +[](dart::dynamics::EulerJoint* self,
-              dart::dynamics::EulerJoint::AxisOrder _order) {
+              dart::dynamics::detail::AxisOrder _order) {
             self->setAxisOrder(_order);
           },
           ::py::arg("order"))
       .def(
           "setAxisOrder",
           +[](dart::dynamics::EulerJoint* self,
-              dart::dynamics::EulerJoint::AxisOrder _order,
+              dart::dynamics::detail::AxisOrder _order,
               bool _renameDofs) { self->setAxisOrder(_order, _renameDofs); },
           ::py::arg("order"),
           ::py::arg("renameDofs"))
       .def(
           "getAxisOrder",
           +[](const dart::dynamics::EulerJoint* self)
-              -> dart::dynamics::EulerJoint::AxisOrder {
+              -> dart::dynamics::detail::AxisOrder {
             return self->getAxisOrder();
           })
       .def(
@@ -209,7 +209,7 @@ void EulerJoint(py::module& m)
       .def_static(
           "convertToTransformOf",
           +[](const Eigen::Vector3s& _positions,
-              dart::dynamics::EulerJoint::AxisOrder _ordering,
+              dart::dynamics::detail::AxisOrder _ordering,
               const Eigen::Vector3s& flipAxisMap
               = Eigen::Vector3s::Ones()) -> Eigen::Isometry3s {
             return dart::dynamics::EulerJoint::convertToTransform(
@@ -221,7 +221,7 @@ void EulerJoint(py::module& m)
       .def_static(
           "convertToRotationOf",
           +[](const Eigen::Vector3s& _positions,
-              dart::dynamics::EulerJoint::AxisOrder _ordering,
+              dart::dynamics::detail::AxisOrder _ordering,
               const Eigen::Vector3s& flipAxisMap
               = Eigen::Vector3s::Ones()) -> Eigen::Matrix3s {
             return dart::dynamics::EulerJoint::convertToRotation(

--- a/python/_nimblephysics/math/Geometry.cpp
+++ b/python/_nimblephysics/math/Geometry.cpp
@@ -301,5 +301,20 @@ void Geometry(py::module& m)
       .def("computeHalfExtents", &dart::math::BoundingBox::computeHalfExtents);
 }
 
+void EulerGeometry(py::module& m)
+{
+  m.def(
+      "roundEulerAnglesToNearest",
+      +[](Eigen::Vector3s angle,
+          Eigen::Vector3s previousAngle,
+          dynamics::detail::AxisOrder axisOrder) -> Eigen::Vector3s {
+        return dart::math::roundEulerAnglesToNearest(
+            angle, previousAngle, axisOrder);
+      },
+      ::py::arg("angle"),
+      ::py::arg("previousAngle"),
+      ::py::arg("axisOrder") = dart::dynamics::detail::AxisOrder::XYZ);
+}
+
 } // namespace python
 } // namespace dart

--- a/python/_nimblephysics/math/module.cpp
+++ b/python/_nimblephysics/math/module.cpp
@@ -43,7 +43,7 @@ void MultivariateGaussian(py::module& sm);
 void GraphFlowDiscretizer(py::module& sm);
 void PolynomialFitter(py::module& sm);
 
-void dart_math(py::module& m)
+py::module dart_math(py::module& m)
 {
   auto sm = m.def_submodule("math");
 
@@ -52,6 +52,14 @@ void dart_math(py::module& m)
   MultivariateGaussian(sm);
   GraphFlowDiscretizer(sm);
   PolynomialFitter(sm);
+
+  return sm;
+}
+
+void EulerGeometry(py::module& sm);
+void dart_euler_math(py::module& sm)
+{
+  EulerGeometry(sm);
 }
 
 } // namespace python

--- a/python/_nimblephysics/nimblephysics.cpp
+++ b/python/_nimblephysics/nimblephysics.cpp
@@ -43,7 +43,8 @@ namespace python {
 void eigen_geometry(py::module& m);
 
 void dart_common(py::module& m);
-void dart_math(py::module& m);
+py::module dart_math(py::module& m);
+void dart_euler_math(py::module& m);
 void dart_dynamics(py::module& m);
 void dart_collision(py::module& m);
 void dart_constraint(py::module& m);
@@ -71,9 +72,10 @@ PYBIND11_MODULE(_nimblephysics, m)
   eigen_geometry(m);
 
   dart_common(m);
-  dart_math(m);
+  py::module math_module = dart_math(m);
   dart_performance(m);
   dart_dynamics(m);
+  dart_euler_math(math_module);
   dart_collision(m);
   dart_constraint(m);
   dart_simulation_and_neural(m, neural, withRespectTo);

--- a/python/nimblephysics.egg-info/PKG-INFO
+++ b/python/nimblephysics.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: nimblephysics
-Version: 0.10.45
+Version: 0.10.48
 Summary: A differentiable fully featured physics engine
 Author: Keenon Werling
 Author-email: keenonwerling@gmail.com


### PR DESCRIPTION
This PR adds a few small new Python bindings:
- Adding a binding for unwrapEulerAngles
- Adding support for SubjectOnDisk to record the presence or absence of manual annotations on good GRF frames