### PR TITLE
Add `SubjectOnDiskTrial::getName()`

### DIFF
--- a/dart/biomechanics/SubjectOnDisk.cpp
+++ b/dart/biomechanics/SubjectOnDisk.cpp
@@ -3215,6 +3215,11 @@ void SubjectOnDiskTrial::setName(const std::string& name)
   mName = name;
 }
 
+const std::string& SubjectOnDiskTrial::getName() const
+{
+  return mName;
+}
+
 void SubjectOnDiskTrial::setTimestep(s_t timestep)
 {
   mTimestep = timestep;

--- a/dart/biomechanics/SubjectOnDisk.hpp
+++ b/dart/biomechanics/SubjectOnDisk.hpp
@@ -328,6 +328,7 @@ class SubjectOnDiskTrial
 public:
   SubjectOnDiskTrial();
   void setName(const std::string& name);
+  const std::string& getName() const;
   void setTimestep(s_t timestep);
   s_t getTimestep();
   void setTrialLength(int length);

--- a/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
+++ b/python/_nimblephysics/biomechanics/SubjectOnDisk.cpp
@@ -877,6 +877,9 @@ Note that these are specified in the local body frame, acting on the body at its
                 &dart::biomechanics::SubjectOnDiskTrial::setName,
                 ::py::arg("name"))
             .def(
+                "getName",
+                &dart::biomechanics::SubjectOnDiskTrial::getName)
+            .def(
                 "setTimestep",
                 &dart::biomechanics::SubjectOnDiskTrial::setTimestep,
                 ::py::arg("timestep"))


### PR DESCRIPTION
Pretty straightforward: adds `getName()` to `SubjectOnDiskTrial` to make accessing trial segment names in AddBiomechanics easier.
